### PR TITLE
Proxy improvement

### DIFF
--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -22,11 +22,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
+      - run: echo "JAVA_11=$JAVA_HOME" >> $GITHUB_ENV
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -53,11 +60,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
+      - run: echo "JAVA_11=$JAVA_HOME" >> $GITHUB_ENV
       - name: Install cross-compilation toolchains
         run: |
           sudo apt install -y --force-yes gcc g++ linux-libc-dev libc6-dev
@@ -112,11 +126,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
+      - run: echo "JAVA_11=$JAVA_HOME" >> $GITHUB_ENV
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -147,11 +168,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
+      - run: echo "JAVA_11=$JAVA_HOME" >> $GITHUB_ENV
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,10 @@ subprojects { it ->
     if (it.name != 'android') {
         apply plugin: 'java'
         java {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(8)
+            }
+
             withSourcesJar()
             withJavadocJar()
         }
@@ -42,10 +44,10 @@ apply from: 'publish.gradle'
 apply from: 'jacoco.gradle'
 
 task allJavadoc(type: Javadoc) {
-    source subprojects.findAll {!['example', 'android'].contains(it.name) }.collect {
+    source subprojects.findAll { !['example', 'android'].contains(it.name) }.collect {
         it.sourceSets.main.allJava
     }
-    classpath = files(subprojects.findAll {!['example', 'android'].contains(it.name) }.collect {
+    classpath = files(subprojects.findAll { !['example', 'android'].contains(it.name) }.collect {
         it.sourceSets.main.compileClasspath
     })
     exclude '**/party/iroiro/luajava/util/**'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'party.iroiro.luajava'
-version '3.1.0'
+version '3.1.1-SNAPSHOT'
 
 buildscript {
     repositories {

--- a/docs/.vuepress/components/Asciinema.vue
+++ b/docs/.vuepress/components/Asciinema.vue
@@ -1,6 +1,6 @@
 <script setup>
 import 'asciinema-player/dist/bundle/asciinema-player.css'
-import { ref, onMounted, defineProps } from 'vue'
+import { ref, onMounted } from 'vue'
 
 const cinema = ref(null)
 const props = defineProps(['file'])

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -38,6 +38,7 @@ export default defineUserConfig({
         children: [
           '/api.md',
           '/conversions.md',
+          '/proxy.md',
           '/threadsafety.md',
           '/troubleshooting.md',
         ]

--- a/docs/api.md
+++ b/docs/api.md
@@ -129,6 +129,7 @@ str = java.new(String, 'This is the content of the String')
 ### `proxy (jclass, ..., table)` <Badge>function</Badge>
 
 Creates a Java object implementing the specified interfaces, proxying calls to the underlying Lua table.
+See also [Proxy Caveats](./proxy.md).
 
 - **Parameters:**
 

--- a/docs/examples/hello-world-mod.md
+++ b/docs/examples/hello-world-mod.md
@@ -12,7 +12,7 @@ print = java.method(java.import('java.lang.System').out,'println','java.lang.Obj
 Ansi = java.import('org.fusesource.jansi.Ansi')
 runnable = {
   run = function()
-    print(Ansi:ansi():render('@|magenta,bold Hello |@'):toString())
+    print(Ansi:ansi():render('@|magenta,bold Hello World |@'))
   end
 }
 thread = java.import('java.lang.Thread')(java.proxy('java.lang.Runnable', runnable))

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luajava-docs",
-  "version": "3.1.0",
+  "version": "3.1.1-SNAPSHOT",
   "description": "Documentation for LuaJava",
   "main": "index.js",
   "scripts": {

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,180 @@
+# Proxy Caveats
+
+Both [the Java API](./javadoc/party/iroiro/luajava/Lua.html#createProxy(java.lang.Class[],party.iroiro.luajava.Lua.Conversion)) and [the Lua API](./api.md#proxy-jclass-table-function) provide a way to create Java proxies that delegate calls to a underlying Lua table.
+
+:::: code-group
+::: code-group-item Java API
+```java
+Lua L = new Lua54();
+L.run("return { run = function() print('Hello') end }");
+Runnable r = (Runnable) L.createProxy(new Class[] {Runnable.class}, Lua.Conversion.SEMI);
+```
+:::
+::::
+
+:::: code-group
+::: code-group-item Lua API
+```lua
+r = java.proxy('java.lang.Runnable', {
+  run = function()
+    print('Hello')
+  end
+})
+```
+:::
+::::
+
+However, there are a few thing that you might want to take note of.
+
+::: tip TL;DR
+1. Use `public` interfaces.
+2. Add [ASM](https://search.maven.org/artifact/org.ow2.asm/asm) to your classpath / runtime dependencies to rid `illegal reflective access` warnings.
+:::
+
+## Access Levels
+
+All interfaces implemented should be visible to all classes (i.e., `public`), although things might work for package-private interfaces depending on JVM security settings.
+
+## Default Methods
+
+### Illegal reflective access
+
+Java 8 brings default methods in interfaces. However, the official reflection API is not adjusted accordingly, making it a real pain to reflectively call the default methods from a proxy.
+
+::: tip
+If you are interested, there is an article on this: [Correct Reflective Access to Interface Default Methods in Java 8, 9, 10](https://blog.jooq.org/correct-reflective-access-to-interface-default-methods-in-java-8-9-10/). And you might want to check out the workarounds used by Spring: [DefaultMethodInvokingMethodInterceptor.java](https://github.com/spring-projects/spring-data-commons/blob/6a23723f07669e5d4031b3378b3af40e0d15eb82/src/main/java/org/springframework/data/projection/DefaultMethodInvokingMethodInterceptor.java).
+:::
+
+We use `unreflectSpecial` to find the default methods, which is only allowed if the caller is a subclass / subinterface. Since a proxy itself is not considered as a subclass of the implemented interfaces, you will very likely be seeing the following reflection warnings.
+
+```
+WARNING: An illegal reflective access operation has occurred
+WARNING: Illegal reflective access using Lookup on party.iroiro.luajava.LuaProxy (file:...) to interface ...
+WARNING: Please consider reporting this to the maintainers of party.iroiro.luajava.LuaProxy
+WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
+WARNING: All illegal access operations will be denied in a future release
+```
+
+### Workaround
+
+A way to workaround this is to introduce some intermediate interfaces:
+
+```
+Original hierarchy:
+  java.lang.Object
+  |\
+  | \- party.iroiro.luajava.LuaProxy -> has no access
+   \
+    \- the implemented interface1
+    \- the implemented interface2
+
+New hierarchy:
+  java.lang.Object
+  |\
+  | \- party.iroiro.luajava.LuaProxy
+   \
+    \- interface1
+    |   \- the actually implemented interface1 bridge -> has access
+    |
+    \- interface2
+        \- the actually implemented interface2 bridge -> has access
+```
+
+We programmatically generate the intermediate interfaces, injecting some static methods to look up the interfaces and let the final proxy object implement the intermediate interfaces instead. By doing so, we finally obtain "legal reflective access".
+
+The above requires the use of [the ASM library](https://asm.ow2.io) to dynamically create interfaces, which is too heavyweight for this library. You will need to enable it by manually adding the ASM dependency.
+
+- To introduce the ASM workaround:
+  1. Add ASM to your runtime dependencies:
+     ```groovy
+     runtimeOnly 'org.ow2.asm:asm:9.3'
+     ```
+  2. Ensure that the `luajava_lookup` system property is either not set or set to `asm`.
+- To use the default approach, either:
+  - Remove ASM from the classpath / dependencies.
+  - Or set the `luajava_lookup` system property to some other value:
+     ```java
+     System.setProperty("luajava_lookup", "no");
+     ```
+
+::::: tip Try things out
+The [interactive console](./console.md) bundles the ASM library with it. You don't need to enable the ASM workaround:
+
+:::: code-group
+::: code-group-item Lua Snippet
+```lua
+iterImpl = {
+  next = function()
+    i = i - 1
+    return i
+  end,
+  hasNext = function()
+    return i > 0
+  end
+}
+
+iter = java.proxy('java.util.Iterator', iterImpl)
+
+-- The default `remove` throws an UnsupportedOperationException
+iter:remove()
+```
+:::
+::::
+
+:::: code-group
+::: code-group-item With the workaround
+```shell-session
+$ java --illegal-access=debug -jar example-all.jar
+Lua Version: 5.1
+Running Lua 5.1
+>>> iterImpl = {
+  >   next = function()
+  >     i = i - 1
+  >     return i
+  >   end,
+  >   hasNext = function()
+  >     return i > 0
+  >   end
+  > }
+  > 
+  > iter = java.proxy('java.util.Iterator', iterImpl)
+>>> iter:remove()
+java.lang.UnsupportedOperationException: remove
+```
+:::
+::: code-group-item Without
+```shell-session
+$ java -Dluajava_lookup=no --illegal-access=debug -jar example/build/libs/example-all.jar   
+Lua Version: 5.1
+Running Lua 5.1
+>>> iterImpl = {
+  >   next = function()
+  >     i = i - 1
+  >     return i
+  >   end,
+  >   hasNext = function()
+  >     return i > 0
+  >   end
+  > }
+  > 
+  > iter = java.proxy('java.util.Iterator', iterImpl)
+>>> iter:remove()
+WARNING: Illegal reflective access using Lookup on party.iroiro.luajava.util.NastyLookupProvider (file:/tmp/example-all.jar) to interface java.util.Iterator
+	at party.iroiro.luajava.util.NastyLookupProvider.lookup(NastyLookupProvider.java:72)
+	at party.iroiro.luajava.util.ClassUtils.invokeDefault(ClassUtils.java:314)
+	at party.iroiro.luajava.LuaProxy.callDefaultMethod(LuaProxy.java:77)
+	at party.iroiro.luajava.LuaProxy.invoke(LuaProxy.java:39)
+	at com.sun.proxy.$Proxy1.remove(Unknown Source)
+	at party.iroiro.luajava.JuaAPI.methodInvoke(JuaAPI.java:546)
+	at party.iroiro.luajava.JuaAPI.methodInvoke(JuaAPI.java:490)
+	at party.iroiro.luajava.JuaAPI.objectInvoke(JuaAPI.java:203)
+	at party.iroiro.luajava.Lua51Natives.luaL_dostring(Native Method)
+	at party.iroiro.luajava.AbstractLua.run(AbstractLua.java:490)
+	at party.iroiro.luajava.Console.startInteractive(Console.java:64)
+	at party.iroiro.luajava.Console.main(Console.java:31)
+java.lang.UnsupportedOperationException: remove
+```
+:::
+::::
+
+:::::

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -13,8 +13,11 @@ ext {
     jlineVersion = '3.21.0'
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
 
 dependencies {
     implementation project(':luajava')
@@ -42,6 +45,12 @@ dependencies {
 
 test {
     useJUnitPlatform()
+
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    })
+
+    jvmArgs ["--illegal-access=debug"]
 
     jacoco {
         destinationFile = project(':').buildDir.toPath().resolve('jacoco/test.exec').toFile()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation "org.jline:jline-terminal:$jlineVersion"
     implementation "org.jline:jline-builtins:$jlineVersion"
     implementation "org.jline:jline-terminal-jansi:$jlineVersion"
+    runtimeOnly 'org.ow2.asm:asm:9.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'

--- a/example/src/test/java/party/iroiro/luajava/LuaTestSuite.java
+++ b/example/src/test/java/party/iroiro/luajava/LuaTestSuite.java
@@ -1,5 +1,6 @@
 package party.iroiro.luajava;
 
+import party.iroiro.luajava.suite.DefaultProxyTest;
 import party.iroiro.luajava.value.LuaValue;
 
 import java.lang.reflect.Array;
@@ -89,6 +90,8 @@ public class LuaTestSuite<T extends Lua> {
         proxyIntegerTest.set(0);
         ((Runnable) proxy).run();
         assertEquals(-1024, proxyIntegerTest.get());
+
+        new DefaultProxyTest(L).test();
     }
 
     private void testOthers() {

--- a/example/src/test/java/party/iroiro/luajava/LuaTestSuite.java
+++ b/example/src/test/java/party/iroiro/luajava/LuaTestSuite.java
@@ -80,7 +80,7 @@ public class LuaTestSuite<T extends Lua> {
     public static final AtomicInteger proxyIntegerTest = new AtomicInteger(0);
     private void testProxy() {
         L.push(true);
-        assertNull(L.createProxy(new Class[0], Lua.Conversion.NONE));
+        assertThrows(IllegalArgumentException.class, () -> L.createProxy(new Class[0], Lua.Conversion.NONE));
         assertEquals(OK, L.run("proxyMap = { run = function()\n" +
                 "java.import('party.iroiro.luajava.LuaTestSuite').proxyIntegerTest:set(-1024)\n" +
                 "end" +

--- a/example/src/test/java/party/iroiro/luajava/suite/B.java
+++ b/example/src/test/java/party/iroiro/luajava/suite/B.java
@@ -1,0 +1,7 @@
+package party.iroiro.luajava.suite;
+
+public interface B {
+    default int b() {
+        return ((DefaultProxyTest.A) this).a() + 2;
+    }
+}

--- a/example/src/test/java/party/iroiro/luajava/suite/DefaultProxyTest.java
+++ b/example/src/test/java/party/iroiro/luajava/suite/DefaultProxyTest.java
@@ -6,7 +6,10 @@ import party.iroiro.luajava.LuaProxy;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -97,9 +100,10 @@ public class DefaultProxyTest {
 
     private void exceptionTest() {
         L.run("return {}");
-        assertEquals("java.lang.String is not an interface",
+        assertTrue(
                 assertThrows(IllegalArgumentException.class,
-                        () -> L.createProxy(new Class[]{String.class}, Lua.Conversion.SEMI)).getMessage()
+                        () -> L.createProxy(new Class[]{String.class}, Lua.Conversion.SEMI))
+                        .getMessage().contains("can not implement java.lang.String")
         );
         L.run("return {}");
         L.push(L.createProxy(new Class[]{A.class}, Lua.Conversion.SEMI), Lua.Conversion.NONE);
@@ -166,19 +170,13 @@ public class DefaultProxyTest {
         }
     }
 
-    interface B {
-        default int b() {
-            return ((A) this).a() + 2;
-        }
-    }
-
-    interface D {
+    public interface D {
         default int dup() {
             return 2;
         }
     }
 
-    interface C extends A {
+    public interface C extends A {
         default int c() {
             return a() + 3;
         }

--- a/example/src/test/java/party/iroiro/luajava/suite/DefaultProxyTest.java
+++ b/example/src/test/java/party/iroiro/luajava/suite/DefaultProxyTest.java
@@ -1,0 +1,120 @@
+package party.iroiro.luajava.suite;
+
+import party.iroiro.luajava.Lua;
+import party.iroiro.luajava.LuaException;
+import party.iroiro.luajava.LuaProxy;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.Callable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DefaultProxyTest {
+    public interface DefaultRunnable extends Callable<Integer> {
+        @Override
+        default Integer call() {
+            return 1024;
+        }
+
+        default void throwsError() {
+            throw new LuaException("exception!");
+        }
+
+        boolean equals();
+
+        void luaError();
+
+        int luaError(int i);
+    }
+
+    private final Lua L;
+
+    public DefaultProxyTest(Lua L) {
+        this.L = L;
+    }
+
+    public void testMethodEquals() throws Throwable {
+        Method equals = Object.class.getMethod("equals", Object.class);
+        Method hashCode = Object.class.getMethod("hashCode");
+        Method toString = Object.class.getMethod("toString");
+        assertTrue(
+                LuaProxy.methodEquals(equals, boolean.class, "equals", Object.class)
+        );
+        assertTrue(
+                LuaProxy.methodEquals(hashCode, int.class, "hashCode")
+        );
+        assertTrue(
+                LuaProxy.methodEquals(toString, String.class, "toString")
+        );
+        assertFalse(
+                LuaProxy.methodEquals(equals, int.class, "equals", Object.class)
+        );
+        assertFalse(
+                LuaProxy.methodEquals(equals, boolean.class, "equal", Object.class)
+        );
+        assertFalse(
+                LuaProxy.methodEquals(equals, boolean.class, "equals", Integer.class)
+        );
+    }
+
+    public void test() {
+        assertDoesNotThrow(this::testMethodEquals);
+        L.run("return { luaError = function(_, i)\n" +
+              "assert(i == 2 or i == 3)\n" +
+              "if i == 2 then return nil else return 3 end\n" +
+              "end }");
+        DefaultRunnable proxy =
+                (DefaultRunnable) L.createProxy(new Class[]{DefaultRunnable.class}, Lua.Conversion.SEMI);
+        assertEquals(1024, proxy.call());
+        assertEquals(Proxy.getInvocationHandler(proxy).hashCode(), proxy.hashCode());
+        // noinspection SimplifiableAssertion,EqualsWithItself
+        assertTrue(proxy.equals(proxy));
+        // noinspection SimplifiableAssertion,EqualsBetweenInconvertibleTypes
+        assertFalse(proxy.equals(L));
+        assertEquals("LuaProxy:interface party.iroiro.luajava.suite.DefaultProxyTest$DefaultRunnable,[]@"
+                     + Integer.toHexString(proxy.hashCode()), proxy.toString());
+        LuaException exception = assertThrows(LuaException.class, proxy::equals);
+        assertTrue(exception.getMessage().startsWith("method not implemented: "));
+
+        assertEquals("exception!",
+                assertThrows(LuaException.class, proxy::throwsError).getMessage());
+
+        assertTrue(assertThrows(LuaException.class, proxy::luaError).getMessage()
+                .contains("assertion failed"));
+        assertTrue(assertThrows(LuaException.class, () -> proxy.luaError(1)).getMessage()
+                .contains("assertion failed"));
+        assertTrue(assertThrows(IllegalArgumentException.class, () -> proxy.luaError(2)).getMessage()
+                .contains("Primitive not accepting null values"));
+        assertEquals(3., proxy.luaError(3));
+
+        hierarchyTest();
+    }
+
+    private void hierarchyTest() {
+        L.createTable(0, 0);
+        Object proxy = L.createProxy(new Class[]{
+                A.class, B.class, C.class,
+        }, Lua.Conversion.SEMI);
+        assertEquals(4, ((C) proxy).c());
+        assertEquals(3, ((B) proxy).b());
+    }
+
+    interface A {
+        default int a() {
+            return 1;
+        }
+    }
+
+    interface B {
+        default int b() {
+            return ((A) this).a() + 2;
+        }
+    }
+
+    interface C extends A {
+        default int c() {
+            return a() + 3;
+        }
+    }
+}

--- a/example/src/test/java/party/iroiro/luajava/suite/DefaultProxyTest.java
+++ b/example/src/test/java/party/iroiro/luajava/suite/DefaultProxyTest.java
@@ -6,9 +6,11 @@ import party.iroiro.luajava.LuaProxy;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.*;
 import java.util.concurrent.Callable;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static party.iroiro.luajava.Lua.LuaError.OK;
 
 public class DefaultProxyTest {
     public interface DefaultRunnable extends Callable<Integer> {
@@ -89,6 +91,29 @@ public class DefaultProxyTest {
         assertEquals(3., proxy.luaError(3));
 
         hierarchyTest();
+        simpleIterTest();
+    }
+
+    private void simpleIterTest() {
+        L.run("i = 10");
+        assertEquals(OK, L.run("return {\n" +
+              "  next = function()\n" +
+              "    i = i - 1\n" +
+              "    return i\n" +
+              "  end,\n" +
+              "  hasNext = function()\n" +
+              "    return i > 0\n" +
+              "  end\n" +
+              "}"));
+        Iterator<?> iter = (Iterator<?>)
+                L.createProxy(new Class[]{Iterator.class}, Lua.Conversion.SEMI);
+        Set<Double> iset = new HashSet<>();
+        iter.forEachRemaining(i -> {
+            if (i instanceof Double) {
+                assertTrue(iset.add((Double) i));
+            }
+        });
+        assertEquals(10, iset.size(), Arrays.toString(iset.toArray()));
     }
 
     private void hierarchyTest() {

--- a/example/src/test/resources/suite/proxyTest.lua
+++ b/example/src/test/resources/suite/proxyTest.lua
@@ -12,3 +12,16 @@ runnable = java.proxy('java.lang.Runnable', t)
 assert(t.value == 1)
 runnable:run()
 assert(t.value == 2)
+
+iterImpl = {
+  next = function()
+    i = i - 1
+    return i
+  end,
+  hasNext = function()
+    return i > 0
+  end
+}
+
+iter = java.proxy('java.util.Iterator', iterImpl)
+assertThrows('java.lang.UnsupportedOperationException', iter.remove, iter)

--- a/lua51/build.gradle
+++ b/lua51/build.gradle
@@ -27,9 +27,6 @@ configurations {
     }
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
-
 dependencies {
     api project(':luajava')
     implementation 'com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1'

--- a/lua52/build.gradle
+++ b/lua52/build.gradle
@@ -27,9 +27,6 @@ configurations {
     }
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
-
 dependencies {
     api project(':luajava')
     implementation 'com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1'

--- a/lua53/build.gradle
+++ b/lua53/build.gradle
@@ -27,9 +27,6 @@ configurations {
     }
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
-
 dependencies {
     api project(':luajava')
     implementation 'com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1'

--- a/lua54/build.gradle
+++ b/lua54/build.gradle
@@ -27,9 +27,6 @@ configurations {
     }
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
-
 dependencies {
     api project(':luajava')
     implementation 'com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1'

--- a/luajava/build.gradle
+++ b/luajava/build.gradle
@@ -11,10 +11,17 @@ repositories {
 group = rootProject.group
 version = rootProject.version
 
+java {
+    registerFeature('proxy') {
+        usingSourceSet(sourceSets.main)
+    }
+}
+
 dependencies {
     implementation 'com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1'
     implementation 'com.google.errorprone:error_prone_annotations:2.14.0'
     implementation 'org.jetbrains:annotations:23.0.0'
+    proxyImplementation 'org.ow2.asm:asm:9.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     testImplementation 'org.mockito:mockito-core:4.6.1'

--- a/luajava/build.gradle
+++ b/luajava/build.gradle
@@ -11,9 +11,6 @@ repositories {
 group = rootProject.group
 version = rootProject.version
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
-
 dependencies {
     implementation 'com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1'
     implementation 'com.google.errorprone:error_prone_annotations:2.14.0'
@@ -21,6 +18,10 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     testImplementation 'org.mockito:mockito-core:4.6.1'
+}
+
+tasks.withType(JavaCompile) {
+    options.deprecation = true
 }
 
 test {

--- a/luajava/src/main/java/party/iroiro/luajava/AbstractLua.java
+++ b/luajava/src/main/java/party/iroiro/luajava/AbstractLua.java
@@ -666,18 +666,17 @@ public abstract class AbstractLua implements Lua {
     }
 
     @Override
-    public Object createProxy(Class<?>[] interfaces, Conversion degree) {
+    public Object createProxy(Class<?>[] interfaces, Conversion degree)
+            throws IllegalArgumentException {
         if (isTable(-1) && interfaces.length >= 1) {
             return Proxy.newProxyInstance(
                     Jua.class.getClassLoader(),
                     interfaces,
-                    new LuaProxy(ref(), this, degree,
-                            interfaces[0], Arrays.copyOfRange(interfaces, 1, interfaces.length))
+                    new LuaProxy(ref(), this, degree, interfaces)
             );
-        } else {
-            pop(1);
-            return null;
         }
+        pop(1);
+        throw new IllegalArgumentException("Expecting a table and interfaces");
     }
 
     @Override

--- a/luajava/src/main/java/party/iroiro/luajava/AbstractLua.java
+++ b/luajava/src/main/java/party/iroiro/luajava/AbstractLua.java
@@ -667,11 +667,12 @@ public abstract class AbstractLua implements Lua {
 
     @Override
     public Object createProxy(Class<?>[] interfaces, Conversion degree) {
-        if (isTable(-1)) {
+        if (isTable(-1) && interfaces.length >= 1) {
             return Proxy.newProxyInstance(
                     Jua.class.getClassLoader(),
                     interfaces,
-                    new LuaProxy(ref(), this, degree)
+                    new LuaProxy(ref(), this, degree,
+                            interfaces[0], Arrays.copyOfRange(interfaces, 1, interfaces.length))
             );
         } else {
             pop(1);

--- a/luajava/src/main/java/party/iroiro/luajava/Lua.java
+++ b/luajava/src/main/java/party/iroiro/luajava/Lua.java
@@ -960,8 +960,9 @@ public interface Lua extends AutoCloseable {
      * @param interfaces the interfaces to implement
      * @param degree     the conversion degree when passing parameters and return values
      * @return a proxy object, calls to which are proxied to the underlying Lua table
+     * @throws IllegalArgumentException if not all classes are interfaces
      */
-    Object createProxy(Class<?>[] interfaces, Conversion degree);
+    Object createProxy(Class<?>[] interfaces, Conversion degree) throws IllegalArgumentException;
 
     /**
      * Registers the function to a global name

--- a/luajava/src/main/java/party/iroiro/luajava/LuaException.java
+++ b/luajava/src/main/java/party/iroiro/luajava/LuaException.java
@@ -1,0 +1,10 @@
+package party.iroiro.luajava;
+
+/**
+ * A wrapper around a Lua error message
+ */
+public class LuaException extends RuntimeException {
+    public LuaException(String message) {
+        super(message);
+    }
+}

--- a/luajava/src/main/java/party/iroiro/luajava/LuaProxy.java
+++ b/luajava/src/main/java/party/iroiro/luajava/LuaProxy.java
@@ -1,5 +1,7 @@
 package party.iroiro.luajava;
 
+import party.iroiro.luajava.util.ClassUtils;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -9,6 +11,7 @@ import java.util.Arrays;
  * This class is used in the LuaJava's proxy system.
  * When a proxy object is accessed, the method invoked is
  * called from Lua
+ *
  * @author Rizzato
  * @author Thiago Ponte
  */
@@ -16,28 +19,44 @@ public class LuaProxy implements InvocationHandler {
     private final int ref;
     private final Lua L;
     private final Lua.Conversion degree;
+    private final Class<?> mainInterface;
+    private final Class<?>[] extraInterfaces;
 
-    LuaProxy(int ref, Lua L, Lua.Conversion degree) {
+    LuaProxy(int ref, Lua L, Lua.Conversion degree,
+             Class<?> mainInterface, Class<?>[] extraInterfaces) {
         this.ref = ref;
         this.L = L;
         this.degree = degree;
+        this.mainInterface = mainInterface;
+        this.extraInterfaces = Arrays.copyOf(extraInterfaces, extraInterfaces.length);
     }
 
     @Override
-    public Object invoke(Object ignored, Method method, Object[] objects) {
+    public Object invoke(Object object, Method method, Object[] objects) throws Throwable {
         synchronized (L.getMainState()) {
             int top = L.getTop();
             L.refGet(ref);
             L.getField(-1, method.getName());
+            if (L.isNil(-1)) {
+                L.setTop(top);
+                return callDefaultMethod(object, method, objects);
+            }
             L.refGet(ref);
 
             int nResults = method.getReturnType() == Void.TYPE ? 0 : 1;
 
+            Lua.LuaError code;
             if (objects == null) {
-                L.pCall(1, nResults);
+                code = L.pCall(1, nResults);
             } else {
                 Arrays.stream(objects).forEach(o -> L.push(o, degree));
-                L.pCall(objects.length + 1, nResults);
+                code = L.pCall(objects.length + 1, nResults);
+            }
+
+            if (code != Lua.LuaError.OK) {
+                RuntimeException t = new LuaException(L.toString(-1));
+                L.setTop(top);
+                throw t;
             }
 
             try {
@@ -54,5 +73,33 @@ public class LuaProxy implements InvocationHandler {
                 throw e;
             }
         }
+    }
+
+    private Object callDefaultMethod(Object o, Method method, Object[] objects) throws Throwable {
+        if (method.isDefault()) {
+            return ClassUtils.invokeDefault(method.getDeclaringClass(), o, method, objects);
+        }
+        return callObjectDefault(o, method, objects);
+    }
+
+    private Object callObjectDefault(Object o, Method method, Object[] objects) {
+        if (methodEquals(method, int.class, "hashCode")) {
+            return hashCode();
+        }
+        if (methodEquals(method, boolean.class, "equals", Object.class)) {
+            return o == objects[0];
+        }
+        if (methodEquals(method, String.class, "toString")) {
+            return "LuaProxy:" + mainInterface + ","
+                   + Arrays.toString(extraInterfaces) + "@" + Integer.toHexString(hashCode());
+        }
+        throw new LuaException("method not implemented: " + method);
+    }
+
+    public static boolean methodEquals(Method method, Class<?> returnType,
+                                       String name, Class<?>... parameters) {
+        return method.getReturnType() == returnType
+               && name.equals(method.getName())
+               && Arrays.equals(method.getParameterTypes(), parameters);
     }
 }

--- a/luajava/src/main/java/party/iroiro/luajava/LuaProxy.java
+++ b/luajava/src/main/java/party/iroiro/luajava/LuaProxy.java
@@ -19,16 +19,13 @@ public class LuaProxy implements InvocationHandler {
     private final int ref;
     private final Lua L;
     private final Lua.Conversion degree;
-    private final Class<?> mainInterface;
-    private final Class<?>[] extraInterfaces;
+    private final Class<?>[] interfaces;
 
-    LuaProxy(int ref, Lua L, Lua.Conversion degree,
-             Class<?> mainInterface, Class<?>[] extraInterfaces) {
+    LuaProxy(int ref, Lua L, Lua.Conversion degree, Class<?>[] interfaces) {
         this.ref = ref;
         this.L = L;
         this.degree = degree;
-        this.mainInterface = mainInterface;
-        this.extraInterfaces = Arrays.copyOf(extraInterfaces, extraInterfaces.length);
+        this.interfaces = Arrays.copyOf(interfaces, interfaces.length);
     }
 
     @Override
@@ -90,8 +87,7 @@ public class LuaProxy implements InvocationHandler {
             return o == objects[0];
         }
         if (methodEquals(method, String.class, "toString")) {
-            return "LuaProxy:" + mainInterface + ","
-                   + Arrays.toString(extraInterfaces) + "@" + Integer.toHexString(hashCode());
+            return "LuaProxy" + Arrays.toString(interfaces) + "@" + Integer.toHexString(hashCode());
         }
         throw new LuaException("method not implemented: " + method);
     }

--- a/luajava/src/main/java/party/iroiro/luajava/LuaProxy.java
+++ b/luajava/src/main/java/party/iroiro/luajava/LuaProxy.java
@@ -25,7 +25,7 @@ public class LuaProxy implements InvocationHandler {
         this.ref = ref;
         this.L = L;
         this.degree = degree;
-        this.interfaces = Arrays.copyOf(interfaces, interfaces.length);
+        this.interfaces = interfaces;
     }
 
     @Override
@@ -74,7 +74,7 @@ public class LuaProxy implements InvocationHandler {
 
     private Object callDefaultMethod(Object o, Method method, Object[] objects) throws Throwable {
         if (method.isDefault()) {
-            return ClassUtils.invokeDefault(method.getDeclaringClass(), o, method, objects);
+            return ClassUtils.invokeDefault(o, method, objects);
         }
         return callObjectDefault(o, method, objects);
     }

--- a/luajava/src/main/java/party/iroiro/luajava/util/AsmLookupProvider.java
+++ b/luajava/src/main/java/party/iroiro/luajava/util/AsmLookupProvider.java
@@ -1,0 +1,77 @@
+package party.iroiro.luajava.util;
+
+import org.objectweb.asm.*;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class AsmLookupProvider implements LookupProvider {
+    private final AtomicInteger counter = new AtomicInteger(0);
+    private final ConcurrentMap<String, Class<?>> extenders = new ConcurrentHashMap<>();
+    private final LookupLoader loader = new LookupLoader(LookupLoader.class.getClassLoader());
+
+    private Class<?> lookupExtender(Class<?> iClass) {
+        try {
+            String internalName = Type.getInternalName(iClass);
+            Class<?> extender = extenders.get(internalName);
+            if (extender != null) {
+                return extender;
+            }
+
+            ClassReader reader = new ClassReader("party.iroiro.luajava.util.SampleExtender");
+            ClassWriter writer = new ClassWriter(0);
+            AtomicReference<String> className = new AtomicReference<>();
+            ClassVisitor visitor = new ClassVisitor(Opcodes.ASM4, writer) {
+                @Override
+                public void visit(int version, int access, String name, String signature,
+                                  String superName, String[] interfaces) {
+                    if (internalName.startsWith("java/")) {
+                        name = name + '$' + counter.getAndIncrement();
+                    } else {
+                        name = internalName + "LuaJavaImpl$" + counter.getAndIncrement();
+                    }
+                    cv.visit(version, access, name,
+                            signature, superName, new String[]{internalName});
+                    className.set(name.replace('/', '.'));
+                }
+            };
+            reader.accept(visitor, 0);
+            loader.add(className.get(), writer.toByteArray());
+            extender = loader.findClass(className.get());
+            extenders.put(internalName, extender);
+            return extender;
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private MethodHandles.Lookup fromExtender(Class<?> extender) {
+        try {
+            Method getLookup = extender.getMethod("getLookup");
+            return (MethodHandles.Lookup) getLookup.invoke(null);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public MethodHandle lookup(Method method) throws IllegalAccessException {
+        Class<?> extender = lookupExtender(method.getDeclaringClass());
+        return fromExtender(extender)
+                .unreflectSpecial(method, extender);
+    }
+
+    public Class<?> wrap(Class<?> iClass) {
+        return lookupExtender(iClass);
+    }
+
+    public ClassLoader getLoader() {
+        return loader;
+    }
+}

--- a/luajava/src/main/java/party/iroiro/luajava/util/ClassUtils.java
+++ b/luajava/src/main/java/party/iroiro/luajava/util/ClassUtils.java
@@ -278,7 +278,6 @@ public abstract class ClassUtils {
         }
         return collection.toArray(EMPTY_CLASS_ARRAY);
     }
-
     /*
      * Licensed under the Apache License, Version 2.0 (the "License");
      * you may not use this file except in compliance with the License.
@@ -312,8 +311,9 @@ public abstract class ClassUtils {
 
                 result = MethodHandles.Lookup.class.getDeclaredConstructor(Class.class);
 
-                if (!result.isAccessible())
+                if (!result.isAccessible()) {
                     result.setAccessible(true);
+                }
             }
         } catch (Throwable ignore) {
             // Can no longer access the above in JDK 9
@@ -341,8 +341,8 @@ public abstract class ClassUtils {
         if (CACHED_LOOKUP_CONSTRUCTOR == null) {
             // Java 9 version for Java 8 distribution (jOOQ Open Source Edition)
             //noinspection JavaReflectionMemberAccess
-            Method privateLookupIn =
-                    MethodHandles.class.getMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
+            Method privateLookupIn = MethodHandles.class.getMethod(
+                    "privateLookupIn", Class.class, MethodHandles.Lookup.class);
             MethodHandles.Lookup lookup = (MethodHandles.Lookup)
                     privateLookupIn.invoke(null, interfaceClass, MethodHandles.lookup());
             proxyLookup = lookup.in(interfaceClass);

--- a/luajava/src/main/java/party/iroiro/luajava/util/ClassUtils.java
+++ b/luajava/src/main/java/party/iroiro/luajava/util/ClassUtils.java
@@ -283,10 +283,15 @@ public abstract class ClassUtils {
     static {
         LookupProvider provider;
         try {
-            Class.forName("org.objectweb.asm.ClassReader");
-            provider = (LookupProvider)
-                    Class.forName("party.iroiro.luajava.util.AsmLookupProvider")
-                            .getConstructor().newInstance();
+            String lookup = System.getProperty("luajava_lookup");
+            if (lookup == null || "asm".equals(lookup)) {
+                Class.forName("org.objectweb.asm.ClassReader");
+                provider = (LookupProvider)
+                        Class.forName("party.iroiro.luajava.util.AsmLookupProvider")
+                                .getConstructor().newInstance();
+            } else {
+                provider = new NastyLookupProvider();
+            }
         } catch (ClassNotFoundException | InvocationTargetException | InstantiationException | IllegalAccessException |
                  NoSuchMethodException e) {
             provider = new NastyLookupProvider();

--- a/luajava/src/main/java/party/iroiro/luajava/util/LookupLoader.java
+++ b/luajava/src/main/java/party/iroiro/luajava/util/LookupLoader.java
@@ -1,0 +1,26 @@
+package party.iroiro.luajava.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class LookupLoader extends ClassLoader {
+    private final ConcurrentMap<String, Class<?>> classes = new ConcurrentHashMap<>();
+
+    public LookupLoader(ClassLoader parent) {
+        super(parent);
+    }
+
+    @Override
+    protected Class<?> findClass(String s) throws ClassNotFoundException {
+        Class<?> c = classes.get(s);
+        if (c == null) {
+            throw new ClassNotFoundException(s);
+        } else {
+            return c;
+        }
+    }
+
+    public void add(String name, byte[] content) {
+        classes.put(name, defineClass(name, content, 0, content.length));
+    }
+}

--- a/luajava/src/main/java/party/iroiro/luajava/util/LookupProvider.java
+++ b/luajava/src/main/java/party/iroiro/luajava/util/LookupProvider.java
@@ -1,0 +1,10 @@
+package party.iroiro.luajava.util;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Method;
+
+public interface LookupProvider {
+    Class<?> wrap(Class<?> interfaceClass);
+    MethodHandle lookup(Method method) throws Throwable;
+    ClassLoader getLoader();
+}

--- a/luajava/src/main/java/party/iroiro/luajava/util/NastyLookupProvider.java
+++ b/luajava/src/main/java/party/iroiro/luajava/util/NastyLookupProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * See https://github.com/jOOQ/jOOR/blob/main/jOOR-java-8/src/main/java/org/joor/Reflect.java
+ */
+
+package party.iroiro.luajava.util;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class NastyLookupProvider implements LookupProvider {
+    private final Constructor<MethodHandles.Lookup> CACHED_LOOKUP_CONSTRUCTOR;
+
+    public NastyLookupProvider() {
+        Constructor<MethodHandles.Lookup> result;
+
+        try {
+            try {
+                //noinspection JavaReflectionMemberAccess
+                Optional.class.getMethod("stream");
+                result = null;
+            } catch (NoSuchMethodException e) {
+                // [jOOQ/jOOR#57] [jOOQ/jOOQ#9157]
+                // A JDK 9 guard that prevents "Illegal reflective access operation"
+                // warnings when running the below on JDK 9+
+
+                result = MethodHandles.Lookup.class.getDeclaredConstructor(Class.class);
+
+                if (!result.isAccessible()) {
+                    result.setAccessible(true);
+                }
+            }
+        } catch (Throwable ignore) {
+            // Can no longer access the above in JDK 9
+            result = null;
+        }
+
+        CACHED_LOOKUP_CONSTRUCTOR = result;
+    }
+
+    @Override
+    public Class<?> wrap(Class<?> interfaceClass) {
+        return interfaceClass;
+    }
+
+    public MethodHandle lookup(Method method)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+        MethodHandles.Lookup proxyLookup;
+
+        // Java 9 version
+        if (CACHED_LOOKUP_CONSTRUCTOR == null) {
+            // Java 9 version for Java 8 distribution (jOOQ Open Source Edition)
+            //noinspection JavaReflectionMemberAccess
+            Method privateLookupIn = MethodHandles.class.getMethod(
+                    "privateLookupIn", Class.class, MethodHandles.Lookup.class);
+            MethodHandles.Lookup lookup = (MethodHandles.Lookup)
+                    privateLookupIn.invoke(null, method.getDeclaringClass(), MethodHandles.lookup());
+            proxyLookup = lookup.in(method.getDeclaringClass());
+        } else {
+            proxyLookup = CACHED_LOOKUP_CONSTRUCTOR.newInstance(method.getDeclaringClass());
+        }
+
+        return proxyLookup.unreflectSpecial(method, method.getDeclaringClass());
+    }
+
+    @Override
+    public ClassLoader getLoader() {
+        return getClass().getClassLoader();
+    }
+}

--- a/luajava/src/main/java/party/iroiro/luajava/util/SampleExtender.java
+++ b/luajava/src/main/java/party/iroiro/luajava/util/SampleExtender.java
@@ -1,0 +1,11 @@
+package party.iroiro.luajava.util;
+
+import java.lang.invoke.MethodHandleInfo;
+import java.lang.invoke.MethodHandles;
+
+@SuppressWarnings("unused")
+public interface SampleExtender extends MethodHandleInfo {
+    static MethodHandles.Lookup getLookup() {
+        return MethodHandles.lookup();
+    }
+}

--- a/luajit/build.gradle
+++ b/luajit/build.gradle
@@ -29,9 +29,6 @@ configurations {
     }
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
-
 dependencies {
     api project(':luajava')
     implementation 'com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1'


### PR DESCRIPTION
Fixes #22: delegating calls to interface default methods.

1. `createProxy` now throws exceptions instead of returning `null`.
2. If no Lua method is found, fallback to the following:
   - Default methods in implemented interfaces,
   - Basic implementation of `equals`, `hashCode` and `toString`.
3. Default methods are looked up with:
   - `MethodHandles.lookup()` or `MethodHandles.privateLookup()` when ASM is not on the classpath
   - `MethodHandles.lookup()` created by a dynamically generated intermediate interface