### PR TITLE
Supporting import of nested packages / classes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -83,19 +83,27 @@ Import a Java class or package.
     - `name`: (***string***) Either of the following
       * The full name, including the package part, of the class.
 
-      * A package name, appended with `.*`.
+      * Any string, appended with possibly multiple `.*`.
 
 - **Returns:**
 
     - (***jclass***) If `name` is the name of a class, return a `jclass` of the class.
 
-    - (***table***) If `name` is a package name, appended with `.*`, return a Lua table, including all classes directly under the package.
+    - (***table***) If `name` is a string appended with `.*`, return a Lua table,
+      which looks up classes directly under a package or inner classes inside a class when indexed.
+      See the following example for details.
 
 - Generates a Lua error if class not found.
 
 ```lua
 lang = java.import('java.lang.*')
 print(lang.System:currentTimeMillis())
+
+R = java.import('android.R.*')
+print(R.id.input)
+
+j = java.import('java.*.*')
+print(j.lang.System:currentMillis())
 
 System = java.import('java.lang.System')
 print(System:currentTimeMillis())

--- a/example/src/test/resources/suite/importTest.lua
+++ b/example/src/test/resources/suite/importTest.lua
@@ -14,4 +14,7 @@ String = lang.String
 assert(String ~= nil)
 assert(type(String) == 'userdata')
 
-assertThrows('bad argument #1 to \'java.import\'', function() print(lang[nil]) end)
+assertThrows("bad argument #2 to",
+             function() print(lang[nil]) end)
+assertThrows("java.lang.ClassNotFoundException: java.lang.",
+             function() print(lang['']) end)

--- a/jni/luajava/jua.h
+++ b/jni/luajava/jua.h
@@ -9,6 +9,7 @@
 extern const char JAVA_CLASS_META_REGISTRY[];
 extern const char JAVA_OBJECT_META_REGISTRY[];
 extern const char JAVA_ARRAY_META_REGISTRY[];
+extern const char JAVA_PACKAGE_META_REGISTRY[];
 
 extern jclass    juaapi_class;
 extern jmethodID juaapi_classnew;

--- a/jni/luajava/jualib.h
+++ b/jni/luajava/jualib.h
@@ -3,6 +3,8 @@
 
 #define LUA_JAVALIBNAME "java"
 
+int javaImport(lua_State * L);
+
 extern const luaL_Reg javalib[];
 
 #endif /* JUALIB_H! */

--- a/luajava/src/main/java/party/iroiro/luajava/JuaAPI.java
+++ b/luajava/src/main/java/party/iroiro/luajava/JuaAPI.java
@@ -101,30 +101,12 @@ public abstract class JuaAPI {
     @SuppressWarnings("unused")
     public static int javaImport(int id, String className) {
         Lua L = Jua.get(id);
-        if (className.endsWith(".*")) {
-            L.createTable(0, 0);
-            L.createTable(0, 1);
-            String packageName = className.substring(0, className.length() - 1);
-            L.push(l -> {
-                String name = l.toString(-1);
-                if (name != null) {
-                    return javaImport(l.getId(), packageName + name);
-                } else {
-                    L.push("bad argument #1 to 'java.import' (expecting string)");
-                    return -1;
-                }
-            });
-            L.setField(-2, "__index");
-            L.setMetatable(-2);
+        try {
+            L.pushJavaClass(ClassUtils.forName(className, null));
             return 1;
-        } else {
-            try {
-                L.pushJavaClass(ClassUtils.forName(className, null));
-                return 1;
-            } catch (ClassNotFoundException e) {
-                L.push(e.toString());
-                return -1;
-            }
+        } catch (ClassNotFoundException e) {
+            L.push(e.toString());
+            return -1;
         }
     }
 


### PR DESCRIPTION
* Extends 'package.\*' imports to 'package.\*.\*' imports with multiple '.*': #25 
* Caches the imported results: `java.import('java.lang.*')` now remembers queried classes.

```lua
j = java.import('java.*.*')
str = j.lang.String("Hello")
list = j.util.ArrayList()
list:add(str)
j.lang.System.out:println(list)
```