### PR TITLE
Bumped minimum Android API version to that of NDK 26

### DIFF
--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -224,11 +224,13 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [ 23, 26, 29, 31 ]
-        android-arch: [ 'x86_64' ]
+        api-level: [ 21, 24, 27 ]
+        android-arch: [ 'x86_64', 'x86' ]
         include:
-          - api-level: 19
-            android-arch: 'x86'
+          - api-level: 30
+            android-arch: 'x86_64'
+          - api-level: 33
+            android-arch: 'x86_64'
     needs:
       - most-natives
     steps:

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -371,7 +371,8 @@ jobs:
           GPG_SECKEY: ${{ secrets.SIGNING_SECRET_KEY }}
           GITHUB_REF: ${{ github.ref }}
         run: |
-          ./gradlew build publish
+          ./gradlew build -x test
+          ./gradlew publish
       - name: Build example
         run: |
           ./gradlew :example:shadowJar

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ To include LuaJava into your project, you need to include two artifacts, one for
 
 ```groovy
 // Example: LuaJIT with Desktop natives
-implementation 'party.iroiro.luajava:luajit:3.4.1'
-runtimeOnly 'party.iroiro.luajava:luajit-platform:3.4.1:natives-desktop'
+implementation 'party.iroiro.luajava:luajit:3.5.0'
+runtimeOnly 'party.iroiro.luajava:luajit-platform:3.5.0:natives-desktop'
 ```
 
 Different artifacts are provided for different Lua versions and different platforms. Check out [Getting Started](https://gudzpoz.github.io/luajava/getting-started.html) for an overview. Or you may also search in the [Maven Central](https://mvnrepository.com/search?q=party.iroiro.luajava).

--- a/android/android-test/build.gradle
+++ b/android/android-test/build.gradle
@@ -21,8 +21,8 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdk 19
-        targetSdk 19
+        minSdk 21
+        targetSdk 21
         versionCode 1
         versionName '3.1'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ android {
     buildToolsVersion '30.0.3'
 
     defaultConfig {
-        minSdk 19
+        minSdk 21
         targetSdk 31
         versionCode 1
         versionName '3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'party.iroiro.luajava'
-version(System.getenv('IS_RELEASE') == 'true' ? '3.4.1' : '3.4.2-SNAPSHOT')
+version(System.getenv('IS_RELEASE') == 'true' ? '3.5.0' : '3.5.0-SNAPSHOT')
 
 buildscript {
     repositories {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,7 @@ The AAR archive bundles native binaries for `armeabi-v7a` `arm64-v8a` `x86` and 
 ext {
     // You may replace `luajit` with `lua51` or other Lua versions
     lua = 'luajit'
-    luaJavaVersion = '3.4.1'
+    luaJavaVersion = '3.5.0'
 }
 
 dependencies {
@@ -85,7 +85,7 @@ android {
 ext {
     // You may replace `lua51` with `luajit` or other Lua versions
     lua = 'lua51'
-    luajavaVersion = '3.4.1'
+    luajavaVersion = '3.5.0'
 }
 
 configurations { natives }

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,4 +128,5 @@ ul li {
 </table>
 
 [^android]: Android is available on many platforms, and we provide natives for `armeabi-v7a` `arm64-v8a` `x86` `x86_64`.
-            It is tested against API levels 19, 23, 26, 29 and 31 on `x86` / `x86_64` architectures (and against my own phone of API level 30 on `arm64-v8a`).
+            It is tested against API levels 21, 24, 27, 30 and 33 on `x86_64` architectures
+            (and on `x86` if a `default` emulator image is available) (and against my own phone of API level 30 on `arm64-v8a`).

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luajava-docs",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Documentation for LuaJava",
   "main": "index.js",
   "scripts": {

--- a/lua51/build.gradle
+++ b/lua51/build.gradle
@@ -84,8 +84,7 @@ jnigen {
         cFlags += androidFlags
         cppFlags += androidFlags
         androidApplicationMk = [
-                'APP_PLATFORM := android-19',
-                'APP_STL := c++_static',
+                'APP_PLATFORM := android-21',
                 "APP_CFLAG :=$androidFlags",
         ]
     }

--- a/lua52/build.gradle
+++ b/lua52/build.gradle
@@ -84,8 +84,7 @@ jnigen {
         cFlags += androidFlags
         cppFlags += androidFlags
         androidApplicationMk = [
-                'APP_PLATFORM := android-19',
-                'APP_STL := c++_static',
+                'APP_PLATFORM := android-21',
                 "APP_CFLAG :=$androidFlags",
         ]
     }

--- a/lua53/build.gradle
+++ b/lua53/build.gradle
@@ -84,8 +84,7 @@ jnigen {
         cFlags += androidFlags
         cppFlags += androidFlags
         androidApplicationMk = [
-                'APP_PLATFORM := android-19',
-                'APP_STL := c++_static',
+                'APP_PLATFORM := android-21',
                 "APP_CFLAG :=$androidFlags",
         ]
     }

--- a/lua54/build.gradle
+++ b/lua54/build.gradle
@@ -84,8 +84,7 @@ jnigen {
         cFlags += androidFlags
         cppFlags += androidFlags
         androidApplicationMk = [
-                'APP_PLATFORM := android-19',
-                'APP_STL := c++_static',
+                'APP_PLATFORM := android-21',
                 "APP_CFLAG :=$androidFlags",
         ]
     }

--- a/luajit/build.gradle
+++ b/luajit/build.gradle
@@ -182,8 +182,7 @@ jnigen {
         cppFlags += ' -D_FORTIFY_SOURCE=1 '
         androidABIs = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64']
         androidApplicationMk = [
-                'APP_PLATFORM := android-19',
-                'APP_STL := c++_static',
+                'APP_PLATFORM := android-21',
                 'APP_CFLAGS := -D_FORTIFY_SOURCE=1 ',
         ]
         linkerFlags += " -L${projectDir}/jni/luajit/lib/android/\$(TARGET_ARCH_ABI) -lluajit "


### PR DESCRIPTION
The Android building workflow breaks again... Anyway, it is due to [NDK dropping support for KitKat](https://developer.android.com/ndk/downloads/revision_history):

```
Android NDK r26 LTS (September 2023)
[Changelog](https://github.com/android/ndk/wiki/Changelog-r26)

Downloads

        Downloads for this release are available[here](https://github.com/android/ndk/wiki).

Announcements

        KitKat (APIs 19 and 20) is no longer supported.
```

Therefore, we are also bumping our minimum Android API version to 21. (While it *is* a breaking change, we are not going to bump the major version number but only increment the minor digit instead - the Lua-ish way?)