### PR TITLE
Add newTable method at Lua interface

### DIFF
--- a/example/suite/src/main/java/party/iroiro/luajava/LuaTestSuite.java
+++ b/example/suite/src/main/java/party/iroiro/luajava/LuaTestSuite.java
@@ -897,6 +897,10 @@ public class LuaTestSuite<T extends AbstractLua> {
             L.pop(1);
         }
         L.pop(1);
+
+        L.newTable();
+        assertEquals(TABLE, L.type(-1));
+        L.pop(1);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/luajava/src/main/java/party/iroiro/luajava/AbstractLua.java
+++ b/luajava/src/main/java/party/iroiro/luajava/AbstractLua.java
@@ -653,6 +653,11 @@ public abstract class AbstractLua implements Lua {
     }
 
     @Override
+    public void newTable() {
+        createTable(0, 0);
+    }
+
+    @Override
     public void createTable(int nArr, int nRec) {
         checkStack(1);
         C.lua_createtable(L, nArr, nArr);

--- a/luajava/src/main/java/party/iroiro/luajava/Lua.java
+++ b/luajava/src/main/java/party/iroiro/luajava/Lua.java
@@ -762,15 +762,11 @@ public interface Lua extends AutoCloseable {
     /**
      * Creates a new empty table and pushes it onto the stack
      * 
-     * Does the equivalent to createTable(0, 0)
-     * 
      * <p>
-     * The new table but without pre-allocation.
+     * It is equivalent to {@link #createTable(int, int) createTable(0, 0)}.
      * </p>
      */
-    default void newTable() {
-        createTable(0, 0);
-    }
+    void newTable();
 
     /**
      * Pushes onto the stack the value t[key]

--- a/luajava/src/main/java/party/iroiro/luajava/Lua.java
+++ b/luajava/src/main/java/party/iroiro/luajava/Lua.java
@@ -760,6 +760,19 @@ public interface Lua extends AutoCloseable {
     void createTable(int nArr, int nRec);
 
     /**
+     * Creates a new empty table and pushes it onto the stack
+     * 
+     * Does the equivalent to createTable(0, 0)
+     * 
+     * <p>
+     * The new table but without pre-allocation.
+     * </p>
+     */
+    default void newTable() {
+        createTable(0, 0);
+    }
+
+    /**
      * Pushes onto the stack the value t[key]
      *
      * <p>


### PR DESCRIPTION
This PR simply adds `newTable()` method(with default invocation) to Lua interface.

The `newTable` seems exists on native lua code and highly used on beginner-level code instead its equivalent: `createTable(0, 0)`.

Also, because the `LuaNative.newTable` exists, its good to add it into interface too.

I just add it via default method of interface because I use github edit page to modify this but if you want then I'll change it to use method inside LuaNative.