### PR TITLE
feat: enable LUA_COMPAT for Lua 5.2, 5.3, and 5.4

### DIFF
--- a/example/suite/src/main/java/party/iroiro/luajava/LuaTestSuite.java
+++ b/example/suite/src/main/java/party/iroiro/luajava/LuaTestSuite.java
@@ -82,6 +82,7 @@ public class LuaTestSuite<T extends AbstractLua> {
         L.openLibraries();
         LuaScriptSuite.addAssertThrows(L);
         test64BitInteger();
+        testCompat();
         testCoroutineDeadlock();
         testDump();
         testException();
@@ -114,6 +115,25 @@ public class LuaTestSuite<T extends AbstractLua> {
                     LuaError.HANDLER,
                     L.convertError(L.getLuaNatives().lua_pcall(L.getPointer(), 0, 0, -2))
             );
+        }
+    }
+
+    private void testCompat() {
+        L.run("return _VERSION");
+        String version = L.toString(-1);
+
+        switch (version) {
+            case "Lua 5.4": // LUA_COMPAT_5_3
+            case "Lua 5.3": // LUA_COMPAT_5_2
+                L.openLibrary("math");
+                L.run("return math.pow(2, 2)");
+                assertEquals(4, L.toInteger(-1));
+                break;
+            case "Lua 5.2": // LUA_COMPAT_ALL
+                L.openLibrary("math");
+                L.run("return math.log10(1)");
+                assertEquals(0, L.toInteger(-1));
+                break;
         }
     }
 

--- a/lua52/build.gradle
+++ b/lua52/build.gradle
@@ -51,6 +51,8 @@ jnigen {
     sharedLibName = 'lua52'
 
     all {
+        cFlags += ' -DLUA_COMPAT_ALL'
+        cppFlags += ' -DLUA_COMPAT_ALL'
         headerDirs = ['../../jni/luajava', 'mod', 'lua52']
         cppExcludes = ['lua52/**/*']
         cExcludes = ['lua52/**/*']

--- a/lua53/build.gradle
+++ b/lua53/build.gradle
@@ -51,6 +51,8 @@ jnigen {
     sharedLibName = 'lua53'
 
     all {
+        cFlags += ' -DLUA_COMPAT_5_2'
+        cppFlags += ' -DLUA_COMPAT_5_2'
         headerDirs = ['../../jni/luajava', 'mod', 'lua53']
         cppExcludes = ['lua53/**/*']
         cExcludes = ['lua53/**/*']

--- a/lua54/build.gradle
+++ b/lua54/build.gradle
@@ -51,6 +51,8 @@ jnigen {
     sharedLibName = 'lua54'
 
     all {
+        cFlags += ' -DLUA_COMPAT_5_3'
+        cppFlags += ' -DLUA_COMPAT_5_3'
         headerDirs = ['../../jni/luajava', 'mod', 'lua54']
         cppExcludes = ['lua54/**/*']
         cExcludes = ['lua54/**/*']


### PR DESCRIPTION
I think this should take care of #192 as well as the `LUA_COMPAT_XXX` flags for 5.2 and 5.4. 