### PR TITLE
fix: try to load class from multiple class-loaders

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,31 @@
 # Troubleshooting
 
+## Class (or Resource) Not Found
+
+### Is a wrong classloader used?
+
+By default, LuaJava tries the following classloaders for class loading,
+and chooses the first non-null one:
+
+1. `Thread.currentThread().getContextClassLoader()`
+2. `party.iroiro.luajava.util.ClassUtils.class.getClassLoader()`
+3. `ClassLoader.getSystemClassLoader()`
+
+This might not be optimal if your class loading environment is not set up in this hierarchical way.
+You may override `party.iroiro.luajava.util.ClassUtils#DEFAULT_CLASS_LOADER` to use a different class loader.
+(It is not documented in the Javadoc, since it is quite internal and subject to changes.)
+
+### Are you (mistakenly) using Java 9 modules?
+
+If you package a fat JAR with, for example, [shadow](https://github.com/GradleUp/shadow),
+please note that older versions of the plugins may not prune the `module-info.class` from some of your dependencies,
+potentially making the whole JAR a large module.
+
+It should be fine if the fat JAR is the only external JAR you load into the JVM.
+But, if you plan to use this JAR as part of another application (e.g., as a plugin),
+this can cause problems because the module system can restrict reflective access.
+Try moving all `**/*/module-info.class` from your fat JAR.
+
 ## JVM Crashed
 
 The crash is often followed by the following error message:

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'application'
     id 'jacoco'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'me.champeau.jmh' version '0.7.2'
 }
 
 repositories {
@@ -24,6 +25,12 @@ java {
 }
 
 dependencies {
+    jmh project(':luajava')
+    jmh project(':luaj')
+    jmh project(':lua54')
+    jmh project(':luajit')
+    jmh project(path: ':lua54', configuration: 'desktopNatives')
+    jmh project(path: ':luajit', configuration: 'desktopNatives')
     implementation project(':luajava')
     implementation project(':lua51')
     implementation project(':lua52')
@@ -48,6 +55,15 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$jUnitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$jUnitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$jUnitVersion"
+}
+
+jmh {
+    benchmarkMode = ['avgt']
+    fork = 1
+    iterations = 3
+    profilers = ['perfasm']
+    warmupIterations = 2
+    timeUnit = 'us'
 }
 
 test {

--- a/example/src/jmh/java/party/iroiro/luajava/jmh/MethodCallBenchmark.java
+++ b/example/src/jmh/java/party/iroiro/luajava/jmh/MethodCallBenchmark.java
@@ -1,0 +1,52 @@
+package party.iroiro.luajava.jmh;
+
+import org.openjdk.jmh.annotations.*;
+import party.iroiro.luajava.Lua;
+import party.iroiro.luajava.lua54.Lua54;
+import party.iroiro.luajava.luaj.LuaJ;
+import party.iroiro.luajava.luajit.LuaJit;
+
+import java.math.BigInteger;
+
+@State(Scope.Benchmark)
+public class MethodCallBenchmark {
+
+    @Param({"Lua 5.4", "LuaJIT", "LuaJ"})
+    public String lua;
+
+    private Lua L;
+
+    @Setup
+    public void setup() {
+        switch (lua) {
+            case "Lua 5.4":
+                L = new Lua54();
+                break;
+            case "LuaJIT":
+                L = new LuaJit();
+                break;
+            case "LuaJ":
+                L = new LuaJ();
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+        L.set("big_int", BigInteger.valueOf(1024));
+        L.run("int_value = java.method(big_int, 'intValue', '')");
+    }
+
+    @Benchmark
+    public void benchmarkObjectMethodCall() {
+        L.run("assert(big_int:intValue() == 1024)");
+    }
+
+    @Benchmark
+    public void benchmarkModuleMethodCall() {
+        L.run("assert(int_value() == 1024)");
+    }
+
+    @TearDown
+    public void tearDown() {
+        L.close();
+    }
+}

--- a/example/src/jmh/java/party/iroiro/luajava/jmh/SimpleBenchmark.java
+++ b/example/src/jmh/java/party/iroiro/luajava/jmh/SimpleBenchmark.java
@@ -1,0 +1,53 @@
+package party.iroiro.luajava.jmh;
+
+import org.openjdk.jmh.annotations.*;
+import party.iroiro.luajava.ClassPathLoader;
+import party.iroiro.luajava.Lua;
+import party.iroiro.luajava.lua54.Lua54;
+import party.iroiro.luajava.luaj.LuaJ;
+import party.iroiro.luajava.luajit.LuaJit;
+
+@State(Scope.Benchmark)
+public class SimpleBenchmark {
+
+    private void setupLua(Lua L) {
+        L.openLibraries();
+        L.run("io.write = function(s) assert(string.find(s, 'tree', 1, true)) end");
+        L.setExternalLoader(new ClassPathLoader());
+        L.loadExternal("binary-trees");
+        L.setGlobal("benchmark");
+    }
+
+    @Param({"Lua 5.4", "LuaJIT", "LuaJ"})
+    public String lua;
+
+    private Lua L;
+
+    @Setup
+    public void setup() {
+        switch (lua) {
+            case "Lua 5.4":
+                L = new Lua54();
+                break;
+            case "LuaJIT":
+                L = new LuaJit();
+                break;
+            case "LuaJ":
+                L = new LuaJ();
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+        setupLua(L);
+    }
+
+    @Benchmark
+    public void benchmarkBinaryTrees() {
+        L.run("benchmark()");
+    }
+
+    @TearDown
+    public void tearDown() {
+        L.close();
+    }
+}

--- a/example/src/jmh/resources/binary-trees.lua
+++ b/example/src/jmh/resources/binary-trees.lua
@@ -1,0 +1,80 @@
+-- Copyright © 2004-2008 Brent Fulgham, 2005-2024 Isaac Gouy
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+-- 1. Redistributions of source code must retain the above copyright notice,
+-- this list of conditions and the following disclaimer.
+--
+-- 2. Redistributions in binary form must reproduce the above copyright notice,
+-- this list of conditions and the following disclaimer in the documentation
+-- and/or other materials provided with the distribution.
+--
+-- 3. Neither the name "The Computer Language Benchmarks Game" nor the name "The
+-- Benchmarks Game" nor the name "The Computer Language Shootout Benchmarks" nor
+-- the names of its contributors may be used to endorse or promote products
+-- derived from this software without specific prior written permission.
+--
+
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+-- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-- INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+-- CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+-- ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-- POSSIBILITY OF SUCH DAMAGE.
+
+-- The Computer Language Benchmarks Game
+-- https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+-- contributed by Mike Pall
+-- *reset*
+
+local function BottomUpTree(depth)
+  if depth > 0 then
+    depth = depth - 1
+    local left, right = BottomUpTree(depth), BottomUpTree(depth)
+    return { left, right }
+  else
+    return { }
+  end
+end
+
+local function ItemCheck(tree)
+  if tree[1] then
+    return 1 + ItemCheck(tree[1]) + ItemCheck(tree[2])
+  else
+    return 1
+  end
+end
+
+local N = tonumber(arg and arg[1]) or 0
+local mindepth = 4
+local maxdepth = mindepth + 2
+if maxdepth < N then maxdepth = N end
+
+do
+  local stretchdepth = maxdepth + 1
+  local stretchtree = BottomUpTree(stretchdepth)
+  io.write(string.format("stretch tree of depth %d\t check: %d\n",
+    stretchdepth, ItemCheck(stretchtree)))
+end
+
+local longlivedtree = BottomUpTree(maxdepth)
+
+for depth=mindepth,maxdepth,2 do
+  local iterations = 2 ^ (maxdepth - depth + mindepth)
+  local check = 0
+  for i=1,iterations do
+    check = check + ItemCheck(BottomUpTree(depth))
+  end
+  io.write(string.format("%d\t trees of depth %d\t check: %d\n",
+    iterations, depth, check))
+end
+
+io.write(string.format("long lived tree of depth %d\t check: %d\n",
+  maxdepth, ItemCheck(longlivedtree)))

--- a/example/suite/src/main/resources/suite/apiTest.lua
+++ b/example/suite/src/main/resources/suite/apiTest.lua
@@ -105,3 +105,16 @@ assert(currentThread ~= nil) -- Injected by the runner
 assertThrows('unable to detach a main state', java.detach, currentThread)
 subThread = coroutine.create(function() end)
 java.detach(subThread)
+
+--[[
+  java.method
+  ]]--
+-- The following ensures coverage of method caching
+BigInteger = java.import('java.math.BigInteger')
+Constructor = java.method(BigInteger, 'new', 'java.lang.String')
+integer1 = Constructor('100')
+integer2 = Constructor('100')
+assert(integer1:equals(integer2))
+added = java.method(integer1, 'add', 'java.math.BigInteger')(integer2)
+added = java.method(added, 'add', 'java.math.BigInteger')(added)
+assert(integer:intValue() == 400)

--- a/jsr223/src/main/java/party/iroiro/luajava/jsr223/LuaScriptEngine.java
+++ b/jsr223/src/main/java/party/iroiro/luajava/jsr223/LuaScriptEngine.java
@@ -25,7 +25,7 @@ public final class LuaScriptEngine extends AbstractScriptEngine implements Scrip
 
     private Lua getLua() throws ScriptException {
         try {
-            Lua L = (Lua) ClassUtils.forName(luaClass, null).newInstance();
+            Lua L = (Lua) ClassUtils.forName(luaClass).newInstance();
             L.setExternalLoader(new ClassPathLoader());
             L.openLibraries();
             return L;

--- a/jsr223/src/main/java/party/iroiro/luajava/jsr223/LuaScriptEngineFactory.java
+++ b/jsr223/src/main/java/party/iroiro/luajava/jsr223/LuaScriptEngineFactory.java
@@ -183,7 +183,7 @@ public class LuaScriptEngineFactory implements ScriptEngineFactory {
         }
         for (String[] engine : ENGINES) {
             try {
-                ClassUtils.forName(engine[2], null);
+                ClassUtils.forName(engine[2]);
                 return engine;
             } catch (ClassNotFoundException ignored) {
             }

--- a/luajava/src/main/java/party/iroiro/luajava/JuaAPI.java
+++ b/luajava/src/main/java/party/iroiro/luajava/JuaAPI.java
@@ -129,7 +129,7 @@ public abstract class JuaAPI {
     public static int loadLib(int id, String className, String methodName) {
         AbstractLua L = Jua.get(id);
         try {
-            Class<?> clazz = ClassUtils.forName(className, null);
+            Class<?> clazz = ClassUtils.forName(className);
             Method method = clazz.getDeclaredMethod(methodName, Lua.class);
             if (method.getReturnType() == int.class) {
                 //noinspection Convert2Lambda
@@ -199,7 +199,7 @@ public abstract class JuaAPI {
             String name = L.toString(i);
             if (name != null) {
                 try {
-                    return ClassUtils.forName(name, null);
+                    return ClassUtils.forName(name);
                 } catch (ClassNotFoundException e) {
                     return null;
                 }
@@ -224,7 +224,7 @@ public abstract class JuaAPI {
     public static int javaImport(int id, String className) {
         Lua L = Jua.get(id);
         try {
-            L.pushJavaClass(ClassUtils.forName(className, null));
+            L.pushJavaClass(ClassUtils.forName(className));
             return 1;
         } catch (ClassNotFoundException e) {
             return L.error(e);
@@ -362,7 +362,7 @@ public abstract class JuaAPI {
             String iClass = name.substring(0, colon);
             String method = name.substring(colon + 1);
             try {
-                return methodInvoke(index, ClassUtils.forName(iClass, null), obj, method,
+                return methodInvoke(index, ClassUtils.forName(iClass), obj, method,
                         notSignature, paramCount);
             } catch (ClassNotFoundException e) {
                 return Jua.get(index).error(e);
@@ -460,7 +460,7 @@ public abstract class JuaAPI {
                 return 1;
             } else {
                 try {
-                    L.pushJavaClass(ClassUtils.forName(clazz.getName() + '$' + name, null));
+                    L.pushJavaClass(ClassUtils.forName(clazz.getName() + '$' + name));
                     return 1;
                 } catch (ClassNotFoundException e) {
                     return i;
@@ -1028,7 +1028,7 @@ public abstract class JuaAPI {
         Class<?>[] classes = new Class[names.length];
         for (int i = 0; i < names.length; i++) {
             try {
-                classes[i] = ClassUtils.forName(names[i], null);
+                classes[i] = ClassUtils.forName(names[i]);
             } catch (ClassNotFoundException e) {
                 classes[i] = null;
             }

--- a/luajava/src/main/java/party/iroiro/luajava/util/ClassUtils.java
+++ b/luajava/src/main/java/party/iroiro/luajava/util/ClassUtils.java
@@ -114,7 +114,8 @@ public abstract class ClassUtils {
         registerCommonClasses(Throwable.class, Exception.class, RuntimeException.class,
                 Error.class, StackTraceElement.class, StackTraceElement[].class);
         registerCommonClasses(Enum.class, Iterable.class, Iterator.class, Enumeration.class,
-                Collection.class, List.class, Set.class, Map.class, Map.Entry.class, optionalClass());
+                Collection.class, List.class, Set.class, Map.class, Map.Entry.class);
+        registerOptionalClasses();
 
         Class<?>[] javaLanguageInterfaceArray = {Serializable.class, Externalizable.class,
                 Closeable.class, AutoCloseable.class, Cloneable.class, Comparable.class};
@@ -123,14 +124,11 @@ public abstract class ClassUtils {
 
     /**
      * {@code Class requires API level 24 (current min is 19): java.util.Optional}
-     *
-     * @return the class
      */
-    private static @Nullable Class<?> optionalClass() {
+    private static void registerOptionalClasses() {
         try {
-            return Class.forName("java.util.Optional");
-        } catch (ClassNotFoundException e) {
-            return null;
+            registerCommonClasses(Class.forName("java.util.Optional"));
+        } catch (ClassNotFoundException ignored) {
         }
     }
 

--- a/luajava/src/main/java/party/iroiro/luajava/util/LRUCache.java
+++ b/luajava/src/main/java/party/iroiro/luajava/util/LRUCache.java
@@ -1,0 +1,68 @@
+package party.iroiro.luajava.util;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * An LRU-cache based on {@link LinkedHashMap}
+ *
+ * <p>
+ * Basically, this class is intended for method cache with usage like
+ * {@code LRUCache<Class<?>, String, Method>}.
+ * </p>
+ */
+public final class LRUCache<K1, K2, V> {
+
+    private final int innerSize;
+    private final List<Map<K1, Map<K2, V>>> cacheShards;
+
+    public LRUCache(int level1Size, int level2Size, int shards) {
+        this.innerSize = level2Size;
+        ArrayList<Map<K1, Map<K2, V>>> shardList = new ArrayList<>(shards);
+        for (int i = 0; i < shards; i++) {
+            shardList.add(Collections.synchronizedMap(new Cache<>(level1Size)));
+        }
+        this.cacheShards = Collections.unmodifiableList(shardList);
+    }
+
+    @Nullable
+    public V get(K1 k1, K2 k2) {
+        Map<K2, V> inner = getInnerCache(k1);
+        return inner.get(k2);
+    }
+
+    private Map<K2, V> getInnerCache(K1 k1) {
+        int shard = k1.hashCode() % cacheShards.size();
+        Map<K1, Map<K2, V>> cache = cacheShards.get(shard);
+        Map<K2, V> inner = cache.get(k1);
+        if (inner == null) {
+            inner = Collections.synchronizedMap(new Cache<>(innerSize));
+            Map<K2, V> prev = cache.putIfAbsent(k1, inner);
+            if (prev != null) {
+                inner = prev;
+            }
+        }
+        return inner;
+    }
+
+    public void put(K1 k1, K2 k2, V v) {
+        Map<K2, V> inner = getInnerCache(k1);
+        inner.putIfAbsent(k2, v);
+    }
+
+    private final static class Cache<K, V> extends LinkedHashMap<K, V> {
+        private final int maxEntries;
+
+        private Cache(int maxEntries) {
+            super(maxEntries + 1, 0.75F, true);
+            this.maxEntries = maxEntries;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+            return size() > maxEntries;
+        }
+    }
+
+}


### PR DESCRIPTION
Basically, we borrowed `ClassUtils` from Spring, which prioritizes `Thread::getContextClassLoader` over `ClassUtils.class.getClassLoader()`. It is fine in most situations. But sometimes, the library is loaded with an isolated classloader, yet provided with a system classloader in `Thread::getContextClassLoader`, which causes problems.

We simply retry with `ClassUtils.class.getClassLoader()` when failing to load a class. It is not the most efficient, but should be enough (if people cache the lookup results):

```lua
String = java.import('java.lang.String')
s = String('s')
-- instead of
s = java.import('java.lang.String')('s')
```

Also, I also think it is a good chance that we optimize our reflection usage. We were not caching the method lookup results (because Lua is dynamic, and we *do* need to check if every parameter matches (and convert them over) every single time.) Caching the results improves a bit for `L.run("assert(big_num:intValue() == 1024")` but we do need better profiling to get anything meaningful:

```
--- before
Benchmark                                             (lua)  Mode  Cnt  Score   Error  Units
MethodCallBenchmark.benchmarkObjectMethodCall       Lua 5.4  avgt    3  4.660 ± 0.234  us/op
MethodCallBenchmark.benchmarkObjectMethodCall        LuaJIT  avgt    3  3.932 ± 0.100  us/op
MethodCallBenchmark.benchmarkObjectMethodCall          LuaJ  avgt    3  4.003 ± 0.246  us/op
--- after
Benchmark                                             (lua)  Mode  Cnt  Score   Error  Units
MethodCallBenchmark.benchmarkObjectMethodCall       Lua 5.4  avgt    3  2.300 ± 0.038  us/op
MethodCallBenchmark.benchmarkObjectMethodCall        LuaJIT  avgt    3  1.698 ± 0.237  us/op
MethodCallBenchmark.benchmarkObjectMethodCall          LuaJ  avgt    3  1.673 ± 0.018  us/op
```

fixes #200 