### PR TITLE
feat: add conversions between lua strings and java buffers

### DIFF
--- a/docs/conversions.md
+++ b/docs/conversions.md
@@ -15,6 +15,7 @@ When pushing a Java value onto the Lua stack, you can choose from doing a `FULL`
 | Boxed numerics (`Integer`...) |                                | :white_check_mark:             | :white_check_mark:             | `lua_Integer` or `lua_Number`      |
 | `String`                      |                                | :white_check_mark:             | :white_check_mark:             | Lua strings                        |
 | `JFunction`                   |                                | :white_check_mark:             | :white_check_mark:             | A Lua closure                      |
+| `ByteBuffer`                  |                                |                                | :white_check_mark:             | Lua raw strings                    |
 | Java arrays                   |                                |                                | :white_check_mark:             | Lua tables (index starting from 1) |
 | `Collections<?>`              |                                |                                | :white_check_mark:             | Lua tables (index starting from 1) |
 | `Map<?, ?>`                   |                                |                                | :white_check_mark:             | Lua tables                         |
@@ -58,7 +59,7 @@ Currently, there is no way to specify how you want the return value converted.
    Trying to convert a number into an `Object` will always yield a boxed `Double`.
    So pay attention when you use `Object::equals` for example.
 
-4. ***string*** to `String`.
+4. ***string*** to `String` or `ByteBuffer`.
 5. ***table*** to `Map<Object, Object>`, `List<Object&gt;`, `Object[]`, (converted recursively with `Map<Object, Object>` preferred) or any interfaces.
 
    To convert tables into any interface,
@@ -81,6 +82,21 @@ Currently, there is no way to specify how you want the return value converted.
 ::: warning
 Currently, you cannot convert a C closure back to a `JFunction`, even if the closure simply wraps around `JFunction`.
 :::
+
+## Raw Strings in Lua
+
+Unlike Java, Lua allows using strings as raw bytes, which means you can have null bytes,
+invalid UTF-8 sequences, or just arbitrary binary data in a string.
+(See [`lua_pushlstring`](https://www.lua.org/manual/5.1/manual.html#lua_pushlstring) for more information.)
+Java, on the other hand, does not allow this and instead often uses `byte[]` for this purpose.
+
+This poses a challenge when converting between Java `byte[]` and Lua strings:
+the library does not know if the user wishes to interpret the `byte[]` data as an array (mapped to Lua tables) of bytes,
+or as a raw Lua string. Currently, the library assumes the former and does not plan to change until the next major version.
+And before that, you will probably need to write a wrapper yourself with
+[`party.iroiro.luajava.Lua#pushString`](./javadoc/party/iroiro/luajava/Lua.html#push(java.nio.ByteBuffer)){target="_self"}
+and
+[`party.iroiro.luajava.Lua#toBuffer`](./javadoc/party/iroiro/luajava/Lua.html#toBuffer(int)){target="_self"} .
 
 ## 64-Bit Integers
 

--- a/docs/java.md
+++ b/docs/java.md
@@ -35,6 +35,22 @@ To use Lua libraries like `string`, `table` or `coroutine`, you will need to exp
 - [openLibrary](./javadoc/party/iroiro/luajava/Lua.html#openLibrary(java.lang.String)){target="_self"}:
   Opens a specific library.
 
+## Running Lua Files
+
+Lua C API provides a [`luaL_loadfile`](https://www.lua.org/manual/5.4/manual.html#luaL_loadfile){target="_self"} function,
+which loads a Lua file from the file system. 
+However, we deem it less portable to load files from the file system, and have chose to base our API on
+Java classpath loading and Lua's built-in `require` mechanism instead.
+(Actually, you can run any file by loading it into a `ByteBuffer` and running it with
+[`run`](./javadoc/party/iroiro/luajava/Lua.html#run(java.nio.Buffer,java.lang.String)){target="_self"} .)
+
+See [Java-Side Modules](./examples/modules.md) for an example. Basically, to run a file from Java classpath:
+1. Use `L.setExternalLoader(new ClassPathLoader());` to have the `require` function load files from the classpath.
+2. Either run `require('path.to.module')` as Lua code or
+   use [`Lua::require`](./javadoc/party/iroiro/luajava/Lua.html#require(java.lang.String)){target="_self"} to run the file.
+
+<<< ../../example/src/test/java/party/iroiro/luajava/docs/ModuleSnippetTest.java#javaSideModuleTest
+
 ## Interact with Lua values
 
 To interact with Lua values, you can use the [`LuaValue`](#luavalue-interface) interface

--- a/example/src/test/java/party/iroiro/luajava/docs/ModuleSnippetTest.java
+++ b/example/src/test/java/party/iroiro/luajava/docs/ModuleSnippetTest.java
@@ -4,6 +4,10 @@ import org.junit.jupiter.api.Test;
 import party.iroiro.luajava.ClassPathLoader;
 import party.iroiro.luajava.Lua;
 import party.iroiro.luajava.lua51.Lua51;
+import party.iroiro.luajava.value.LuaValue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static party.iroiro.luajava.Lua.LuaType.FUNCTION;
 
 public class ModuleSnippetTest {
     @Test
@@ -12,6 +16,9 @@ public class ModuleSnippetTest {
 try (Lua L = new Lua51()) {
     L.openLibrary("package");
     L.setExternalLoader(new ClassPathLoader());
+    // Lua#require is equivalent to `require` in Lua.
+    LuaValue compat = L.require("suite.luajava-compat");
+    assertEquals(FUNCTION, compat.get("newInstance").type());
 }
 // #endregion classPathLoaderTest
     }

--- a/example/suite/src/main/java/party/iroiro/luajava/LuaScriptSuite.java
+++ b/example/suite/src/main/java/party/iroiro/luajava/LuaScriptSuite.java
@@ -9,6 +9,7 @@ import party.iroiro.luajava.luajit.LuaJitNatives;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.Buffer;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -232,6 +233,7 @@ public class LuaScriptSuite<T extends AbstractLua> {
         public Map<Object, Object> map = null;
         public Override annotation;
         public Runnable intf;
+        public Buffer buffer;
     }
 
     public static abstract class AbstractClass {

--- a/example/suite/src/main/java/party/iroiro/luajava/LuaTestSuite.java
+++ b/example/suite/src/main/java/party/iroiro/luajava/LuaTestSuite.java
@@ -146,7 +146,7 @@ public class LuaTestSuite<T extends AbstractLua> {
     private void testCompat() {
         L.run("return _VERSION");
         String version = L.toString(-1);
-
+        assertNotNull(version);
         switch (version) {
             case "Lua 5.4": // LUA_COMPAT_5_3
             case "Lua 5.3": // LUA_COMPAT_5_2
@@ -393,6 +393,12 @@ public class LuaTestSuite<T extends AbstractLua> {
         try (T L = constructor.get()) {
             L.openLibrary("package");
             L.run("assert(1024 == require('party.iroiro.luajava.JavaLibTest.open').getNumber())");
+        }
+        try (T L = constructor.get()) {
+            assertThrowsLua(
+                    LuaError.RUNTIME,
+                    () -> L.require("luajava.wrongLuaFile")
+            );
         }
     }
 

--- a/example/suite/src/main/java/party/iroiro/luajava/value/LuaValueSuite.java
+++ b/example/suite/src/main/java/party/iroiro/luajava/value/LuaValueSuite.java
@@ -4,6 +4,8 @@ import party.iroiro.luajava.Lua;
 import party.iroiro.luajava.LuaException;
 import party.iroiro.luajava.lua51.Lua51;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -102,12 +104,22 @@ public class LuaValueSuite<T extends Lua> {
         L.push((L, args) -> null);
         LuaValue v = L.get();
         assertTrue(v.toString(), v.toString().startsWith("RefLuaValue$FUNCTION@party.iroiro.luajava.lua"));
+
+        assertEquals("test", L.from(ByteBuffer.wrap("test".getBytes(StandardCharsets.UTF_8))).toString());
     }
 
     private void stringTest() {
         LuaValue value = L.get("_VERSION");
         //noinspection SizeReplaceableByIsEmpty
         assertTrue(value.length() > 0);
+        ByteBuffer buffer = value.toBuffer();
+        byte[] bytes = new byte[buffer.limit()];
+        buffer.get(bytes);
+        assertArrayEquals(
+                value.toString().getBytes(StandardCharsets.UTF_8),
+                bytes
+        );
+
         L.push(10);
         LuaValue i = L.get();
         assertThrows(UnsupportedOperationException.class, i::length);

--- a/example/suite/src/main/java/party/iroiro/luajava/value/LuaValueSuite.java
+++ b/example/suite/src/main/java/party/iroiro/luajava/value/LuaValueSuite.java
@@ -123,6 +123,9 @@ public class LuaValueSuite<T extends Lua> {
         L.push(10);
         LuaValue i = L.get();
         assertThrows(UnsupportedOperationException.class, i::length);
+
+        L.openLibrary("string");
+        assertEquals('t', L.require("string").get("byte").call("test", 1)[0].toInteger());
     }
 
     private void luaStateTest() {

--- a/example/suite/src/main/resources/suite/luaifyTest.lua
+++ b/example/suite/src/main/resources/suite/luaifyTest.lua
@@ -31,3 +31,13 @@ assert(type(iArr) == 'table')
 for i = 8, 12 do
     assert(iArr[i - 7] == i)
 end
+
+buffer = java.import('java.nio.ByteBuffer'):allocateDirect(3)
+buffer:put(1, 1)
+buffer:put(2, 2)
+s = java.luaify(buffer)
+assert(type(s) == 'string')
+assert(#s == 3)
+assert(s:byte(1) == 0)
+assert(s:byte(2) == 1)
+assert(s:byte(3) == 2)

--- a/example/suite/src/main/resources/suite/otherConvTest.lua
+++ b/example/suite/src/main/resources/suite/otherConvTest.lua
@@ -50,3 +50,12 @@ others.intf = { run = function() b = true end }
 assert(others.intf ~= nil)
 others.intf:run()
 assert(b)
+
+assert(others.buffer == nil)
+s = '123'
+others.buffer = s
+assert(others.buffer ~= nil)
+assert(others.buffer:limit() == 3)
+assert(others.buffer:get(0) == s:byte(1))
+assert(others.buffer:get(1) == s:byte(2))
+assert(others.buffer:get(2) == s:byte(3))

--- a/jni/luajava/jua.cpp
+++ b/jni/luajava/jua.cpp
@@ -427,8 +427,16 @@ void luaJ_pushfunction(JNIEnv * env, lua_State * L, jobject func) {
   lua_pushcclosure(L, &jfunctionWrapper, 1);
 }
 
-void luaJ_pushlstring(lua_State * L, unsigned char * buffer, int size) {
-  lua_pushlstring(L, (const char *) buffer, size);
+void luaJ_pushlstring(lua_State * L, unsigned char * buffer, int start, int size) {
+  lua_pushlstring(L, ((const char *) buffer) + start, size);
+}
+
+int luaJ_loadbuffer(lua_State * L, unsigned char * buffer, int start, int size, const char * name) {
+    return luaL_loadbuffer(L, ((const char *) buffer) + start, size, name);
+}
+
+int luaJ_dobuffer(lua_State * L, unsigned char * buffer, int start, int size, const char * name) {
+    return (luaL_loadbuffer(L, ((const char *) buffer) + start, size, name) || lua_pcall(L, 0, LUA_MULTRET, 0));
 }
 
 int luaJ_insertloader(lua_State * L, const char * searchers) {

--- a/jni/luajava/jua.cpp
+++ b/jni/luajava/jua.cpp
@@ -427,6 +427,10 @@ void luaJ_pushfunction(JNIEnv * env, lua_State * L, jobject func) {
   lua_pushcclosure(L, &jfunctionWrapper, 1);
 }
 
+void luaJ_pushlstring(lua_State * L, unsigned char * buffer, int size) {
+  lua_pushlstring(L, (const char *) buffer, size);
+}
+
 int luaJ_insertloader(lua_State * L, const char * searchers) {
   lua_getglobal(L, "package");
   if (lua_isnil(L, -1)) {

--- a/jni/luajava/jua.h
+++ b/jni/luajava/jua.h
@@ -58,6 +58,8 @@ void luaJ_pushclass(JNIEnv * env, lua_State * L, jobject clazz);
 void luaJ_pusharray(JNIEnv * env, lua_State * L, jobject array);
 jobject luaJ_toobject(lua_State * L, int index);
 int luaJ_isobject(lua_State * L, int index);
+void luaJ_pushfunction(JNIEnv * env, lua_State * L, jobject func);
+void luaJ_pushlstring(lua_State * L, unsigned char * buffer, int size);
 
 jobject luaJ_dumptobuffer(lua_State * L);
 jobject luaJ_tobuffer(lua_State * L, int i);

--- a/jni/luajava/jua.h
+++ b/jni/luajava/jua.h
@@ -59,7 +59,10 @@ void luaJ_pusharray(JNIEnv * env, lua_State * L, jobject array);
 jobject luaJ_toobject(lua_State * L, int index);
 int luaJ_isobject(lua_State * L, int index);
 void luaJ_pushfunction(JNIEnv * env, lua_State * L, jobject func);
-void luaJ_pushlstring(lua_State * L, unsigned char * buffer, int size);
+void luaJ_pushlstring(lua_State * L, unsigned char * buffer, int start, int size);
+
+int luaJ_loadbuffer(lua_State * L, unsigned char * buffer, int start, int size, const char * name);
+int luaJ_dobuffer(lua_State * L, unsigned char * buffer, int start, int size, const char * name);
 
 jobject luaJ_dumptobuffer(lua_State * L);
 jobject luaJ_tobuffer(lua_State * L, int i);

--- a/lua51/jni/mod/luacomp.h
+++ b/lua51/jni/mod/luacomp.h
@@ -55,14 +55,6 @@ static int luaJ_len(lua_State * L, int index) {
     return lua_objlen(L, index);
 }
 
-static int luaJ_loadbuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return luaL_loadbuffer(L, (const char *) buffer, size, name);
-}
-
-static int luaJ_dobuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return (luaL_loadbuffer(L, (const char *) buffer, size, name) || lua_pcall(L, 0, LUA_MULTRET, 0));
-}
-
 static int luaJ_resume(lua_State * L, int narg) {
     return lua_resume(L, narg);
 }

--- a/lua51/src/main/java/party/iroiro/luajava/lua51/Lua51Natives.java
+++ b/lua51/src/main/java/party/iroiro/luajava/lua51/Lua51Natives.java
@@ -3322,14 +3322,15 @@ public class Lua51Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -3343,14 +3344,15 @@ public class Lua51Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_dobuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_dobuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -3451,12 +3453,13 @@ public class Lua51Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      */
-    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int start, int size); /*
         lua_State * L = (lua_State *) ptr;
 
-        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size);
     */
 
 

--- a/lua51/src/main/java/party/iroiro/luajava/lua51/Lua51Natives.java
+++ b/lua51/src/main/java/party/iroiro/luajava/lua51/Lua51Natives.java
@@ -3446,6 +3446,24 @@ public class Lua51Natives implements LuaNatives {
      * A wrapper function
      *
      * <p>
+     * Push a buffer as a raw Lua string
+     * </p>
+     *
+     * @param ptr the <code>lua_State*</code> pointer
+     * @param buffer the buffer (expecting direct)
+     * @param size size
+     */
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+        lua_State * L = (lua_State *) ptr;
+
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
+    */
+
+
+    /**
+     * A wrapper function
+     *
+     * <p>
      * Is a Java object (including object, array or class)
      * </p>
      *

--- a/lua52/jni/mod/luacomp.h
+++ b/lua52/jni/mod/luacomp.h
@@ -52,14 +52,6 @@ static int luaJ_len(lua_State * L, int index) {
     return lua_rawlen(L, index);
 }
 
-static int luaJ_loadbuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return luaL_loadbuffer(L, (const char *) buffer, size, name);
-}
-
-static int luaJ_dobuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return (luaL_loadbuffer(L, (const char *) buffer, size, name) || lua_pcall(L, 0, LUA_MULTRET, 0));
-}
-
 static int luaJ_resume(lua_State * L, int narg) {
     return lua_resume(L, NULL, narg);
 }

--- a/lua52/src/main/java/party/iroiro/luajava/lua52/Lua52Natives.java
+++ b/lua52/src/main/java/party/iroiro/luajava/lua52/Lua52Natives.java
@@ -4127,14 +4127,15 @@ public class Lua52Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -4148,14 +4149,15 @@ public class Lua52Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_dobuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_dobuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -4256,12 +4258,13 @@ public class Lua52Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      */
-    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int start, int size); /*
         lua_State * L = (lua_State *) ptr;
 
-        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size);
     */
 
 

--- a/lua52/src/main/java/party/iroiro/luajava/lua52/Lua52Natives.java
+++ b/lua52/src/main/java/party/iroiro/luajava/lua52/Lua52Natives.java
@@ -4251,6 +4251,24 @@ public class Lua52Natives implements LuaNatives {
      * A wrapper function
      *
      * <p>
+     * Push a buffer as a raw Lua string
+     * </p>
+     *
+     * @param ptr the <code>lua_State*</code> pointer
+     * @param buffer the buffer (expecting direct)
+     * @param size size
+     */
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+        lua_State * L = (lua_State *) ptr;
+
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
+    */
+
+
+    /**
+     * A wrapper function
+     *
+     * <p>
      * Is a Java object (including object, array or class)
      * </p>
      *

--- a/lua53/jni/mod/luacomp.h
+++ b/lua53/jni/mod/luacomp.h
@@ -52,14 +52,6 @@ static int luaJ_len(lua_State * L, int index) {
     return lua_rawlen(L, index);
 }
 
-static int luaJ_loadbuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return luaL_loadbuffer(L, (const char *) buffer, size, name);
-}
-
-static int luaJ_dobuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return (luaL_loadbuffer(L, (const char *) buffer, size, name) || lua_pcall(L, 0, LUA_MULTRET, 0));
-}
-
 static int luaJ_resume(lua_State * L, int narg) {
     return lua_resume(L, NULL, narg);
 }

--- a/lua53/src/main/java/party/iroiro/luajava/lua53/Lua53Natives.java
+++ b/lua53/src/main/java/party/iroiro/luajava/lua53/Lua53Natives.java
@@ -4301,14 +4301,15 @@ public class Lua53Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -4322,14 +4323,15 @@ public class Lua53Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_dobuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_dobuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -4430,12 +4432,13 @@ public class Lua53Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      */
-    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int start, int size); /*
         lua_State * L = (lua_State *) ptr;
 
-        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size);
     */
 
 

--- a/lua53/src/main/java/party/iroiro/luajava/lua53/Lua53Natives.java
+++ b/lua53/src/main/java/party/iroiro/luajava/lua53/Lua53Natives.java
@@ -4425,6 +4425,24 @@ public class Lua53Natives implements LuaNatives {
      * A wrapper function
      *
      * <p>
+     * Push a buffer as a raw Lua string
+     * </p>
+     *
+     * @param ptr the <code>lua_State*</code> pointer
+     * @param buffer the buffer (expecting direct)
+     * @param size size
+     */
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+        lua_State * L = (lua_State *) ptr;
+
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
+    */
+
+
+    /**
+     * A wrapper function
+     *
+     * <p>
      * Is a Java object (including object, array or class)
      * </p>
      *

--- a/lua54/jni/mod/luacomp.h
+++ b/lua54/jni/mod/luacomp.h
@@ -52,14 +52,6 @@ static int luaJ_len(lua_State * L, int index) {
     return lua_rawlen(L, index);
 }
 
-static int luaJ_loadbuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return luaL_loadbuffer(L, (const char *) buffer, size, name);
-}
-
-static int luaJ_dobuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return (luaL_loadbuffer(L, (const char *) buffer, size, name) || lua_pcall(L, 0, LUA_MULTRET, 0));
-}
-
 static int luaJ_resume(lua_State * L, int narg) {
     int nresults;
     return lua_resume(L, NULL, narg, &nresults);

--- a/lua54/src/main/java/party/iroiro/luajava/lua54/Lua54Natives.java
+++ b/lua54/src/main/java/party/iroiro/luajava/lua54/Lua54Natives.java
@@ -4439,14 +4439,15 @@ public class Lua54Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -4460,14 +4461,15 @@ public class Lua54Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_dobuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_dobuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -4568,12 +4570,13 @@ public class Lua54Natives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      */
-    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int start, int size); /*
         lua_State * L = (lua_State *) ptr;
 
-        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size);
     */
 
 

--- a/lua54/src/main/java/party/iroiro/luajava/lua54/Lua54Natives.java
+++ b/lua54/src/main/java/party/iroiro/luajava/lua54/Lua54Natives.java
@@ -2888,7 +2888,7 @@ public class Lua54Natives implements LuaNatives {
      * Wrapper of <a href="https://www.lua.org/manual/5.4/manual.html#lua_toclose"><code>lua_toclose</code></a>
      *
      * <pre><code>
-     * [-0, +0, m]
+     * [-0, +0, v]
      * </code></pre>
      *
      * <pre><code>
@@ -2910,6 +2910,11 @@ public class Lua54Natives implements LuaNatives {
      * A slot marked as to-be-closed should not be removed from the stack
      * by any other function in the API except <a href="https://www.lua.org/manual/5.4/manual.html#lua_settop"><code>lua_settop</code></a> or <a href="https://www.lua.org/manual/5.4/manual.html#lua_pop"><code>lua_pop</code></a>,
      * unless previously deactivated by <a href="https://www.lua.org/manual/5.4/manual.html#lua_closeslot"><code>lua_closeslot</code></a>.
+     * </p>
+     *
+     * <p>
+     * This function raises an error if the value at the given slot
+     * neither has a <code>__close</code> metamethod nor is a false value.
      * </p>
      *
      * <p>
@@ -4551,6 +4556,24 @@ public class Lua54Natives implements LuaNatives {
         lua_State * L = (lua_State *) ptr;
 
         luaJ_pushfunction((JNIEnv *) env, (lua_State *) L, (jobject) func);
+    */
+
+
+    /**
+     * A wrapper function
+     *
+     * <p>
+     * Push a buffer as a raw Lua string
+     * </p>
+     *
+     * @param ptr the <code>lua_State*</code> pointer
+     * @param buffer the buffer (expecting direct)
+     * @param size size
+     */
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+        lua_State * L = (lua_State *) ptr;
+
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
     */
 
 

--- a/luaj/src/main/java/party/iroiro/luajava/luaj/LuaJNatives.java
+++ b/luaj/src/main/java/party/iroiro/luajava/luaj/LuaJNatives.java
@@ -240,7 +240,7 @@ public class LuaJNatives implements LuaNatives {
         FunctionInvoker.setFunction(instances.get((int) J), func.checkfunction());
         return thread;
     }
-    
+
     protected void lua_require_coroutine(long ptr) {
         LuaJState L = instances.get((int) ptr);
         L.globals.load(new CoroutineLib() {
@@ -890,6 +890,14 @@ public class LuaJNatives implements LuaNatives {
                 return checkOrError(L, f.__call(Jua.get(L.lid)));
             }
         });
+    }
+
+    @Override
+    public void luaJ_pushlstring(long ptr, Buffer buffer, int size) {
+        LuaJState L = instances.get((int) ptr);
+        byte[] bytes = new byte[size];
+        ((ByteBuffer) buffer).get(bytes);
+        L.push(LuaValue.valueOf(bytes));
     }
 
     @Override

--- a/luaj/src/main/java/party/iroiro/luajava/luaj/LuaJNatives.java
+++ b/luaj/src/main/java/party/iroiro/luajava/luaj/LuaJNatives.java
@@ -807,9 +807,10 @@ public class LuaJNatives implements LuaNatives {
     }
 
     @Override
-    public int luaJ_loadbuffer(long ptr, Buffer buffer, int size, String name) {
+    public int luaJ_loadbuffer(long ptr, Buffer buffer, int start, int size, String name) {
         LuaJState L = instances.get((int) ptr);
-        ByteBuffer bytes = (ByteBuffer) buffer;
+        ByteBuffer bytes = ((ByteBuffer) buffer).duplicate();
+        bytes.position(start).limit(start + size);
         try {
             L.push(
                     L.globals.load(new InputStream() {
@@ -827,8 +828,8 @@ public class LuaJNatives implements LuaNatives {
     }
 
     @Override
-    public int luaJ_dobuffer(long ptr, Buffer buffer, int size, String name) {
-        luaJ_loadbuffer(ptr, buffer, size, name);
+    public int luaJ_dobuffer(long ptr, Buffer buffer, int start, int size, String name) {
+        luaJ_loadbuffer(ptr, buffer, start, size, name);
         return lua_pcall(ptr, 0, LUA_MULTRET, 0);
     }
 
@@ -893,10 +894,12 @@ public class LuaJNatives implements LuaNatives {
     }
 
     @Override
-    public void luaJ_pushlstring(long ptr, Buffer buffer, int size) {
+    public void luaJ_pushlstring(long ptr, Buffer buffer, int start, int size) {
         LuaJState L = instances.get((int) ptr);
         byte[] bytes = new byte[size];
-        ((ByteBuffer) buffer).get(bytes);
+        ByteBuffer duplicate = ((ByteBuffer) buffer).duplicate();
+        duplicate.position(start).limit(start + size);
+        duplicate.get(bytes);
         L.push(LuaValue.valueOf(bytes));
     }
 

--- a/luajava/src/main/java/party/iroiro/luajava/AbstractLua.java
+++ b/luajava/src/main/java/party/iroiro/luajava/AbstractLua.java
@@ -214,7 +214,7 @@ public abstract class AbstractLua implements Lua {
             directBuffer.flip();
             buffer = directBuffer;
         }
-        C.luaJ_pushlstring(L, buffer, buffer.limit());
+        C.luaJ_pushlstring(L, buffer, buffer.position(), buffer.remaining());
     }
 
     @Override
@@ -384,6 +384,11 @@ public abstract class AbstractLua implements Lua {
             }
             if (type == double.class || type == Double.class) {
                 return number.doubleValue();
+            }
+        } else {
+            try {
+                return JuaAPI.convertFromLua(this, type, index);
+            } catch (IllegalArgumentException ignored) {
             }
         }
         return null;
@@ -612,7 +617,7 @@ public abstract class AbstractLua implements Lua {
     public void load(Buffer buffer, String name) throws LuaException {
         if (buffer.isDirect()) {
             checkStack(1);
-            checkError(C.luaJ_loadbuffer(L, buffer, buffer.limit(), name), false);
+            checkError(C.luaJ_loadbuffer(L, buffer, buffer.position(), buffer.remaining(), name), false);
         } else {
             throw new LuaException(LuaException.LuaError.MEMORY, "Expecting a direct buffer");
         }
@@ -628,7 +633,7 @@ public abstract class AbstractLua implements Lua {
     public void run(Buffer buffer, String name) throws LuaException {
         if (buffer.isDirect()) {
             checkStack(1);
-            checkError(C.luaJ_dobuffer(L, buffer, buffer.limit(), name), true);
+            checkError(C.luaJ_dobuffer(L, buffer, buffer.position(), buffer.remaining(), name), true);
         } else {
             throw new LuaException(LuaException.LuaError.MEMORY, "Expecting a direct buffer");
         }

--- a/luajava/src/main/java/party/iroiro/luajava/ClassPathLoader.java
+++ b/luajava/src/main/java/party/iroiro/luajava/ClassPathLoader.java
@@ -41,6 +41,11 @@ import java.util.Objects;
  * {@link #getPath(String)}. For example, loading a {@code abc.def} module
  * will load a Lua file at {@code classpath://abc/def.lua}.
  * </p>
+ *
+ * <p>
+ * To use this class, call {@link Lua#setExternalLoader(ExternalLoader)} with an instance of this class,
+ * and then you can load modules with the Lua {@code require} function from classpath.
+ * </p>
  */
 public class ClassPathLoader implements ExternalLoader {
     protected final ClassLoader classLoader;

--- a/luajava/src/main/java/party/iroiro/luajava/ExternalLoader.java
+++ b/luajava/src/main/java/party/iroiro/luajava/ExternalLoader.java
@@ -33,6 +33,10 @@ public interface ExternalLoader {
     /**
      * Reads an external Lua module file into a direct buffer
      *
+     * <p>
+     * This is used internally by {@link Lua} implementations and should not be called directly.
+     * </p>
+     *
      * @param module the module
      * @param L the Lua state requesting the module
      * @return a direct buffer containing the module file, with position at zero, limit as the length

--- a/luajava/src/main/java/party/iroiro/luajava/JuaAPI.java
+++ b/luajava/src/main/java/party/iroiro/luajava/JuaAPI.java
@@ -649,7 +649,11 @@ public abstract class JuaAPI {
         Method[] methods = MEMBER_METHOD_CACHE.get(clazz, name);
         if (methods == null) {
             List<Method> namedMethods = new ArrayList<>();
-            for (Method method : clazz.getMethods()) {
+            Class<?> publicClass = clazz;
+            while (!Modifier.isPublic(publicClass.getModifiers())) {
+                publicClass = publicClass.getSuperclass();
+            }
+            for (Method method : publicClass.getMethods()) {
                 if (method.getName().equals(name)) {
                     namedMethods.add(method);
                 }
@@ -975,8 +979,12 @@ public abstract class JuaAPI {
             if (clazz == boolean.class || clazz == Boolean.class) {
                 return L.toBoolean(index);
             }
-        } else if (type == Lua.LuaType.STRING && clazz.isAssignableFrom(String.class)) {
-            return L.toString(index);
+        } else if (type == Lua.LuaType.STRING) {
+            if (clazz.isAssignableFrom(String.class)) {
+                return L.toString(index);
+            } else if (clazz.isAssignableFrom(ByteBuffer.class)) {
+                return L.toBuffer(index);
+            }
         } else if (type == Lua.LuaType.NUMBER) {
             if (clazz.isPrimitive() || Number.class.isAssignableFrom(clazz)) {
                 Number v;

--- a/luajava/src/main/java/party/iroiro/luajava/Lua.java
+++ b/luajava/src/main/java/party/iroiro/luajava/Lua.java
@@ -34,6 +34,13 @@ import java.util.*;
 
 /**
  * A {@code lua_State *} wrapper, representing a Lua thread
+ *
+ * <p>
+ * Most methods in this interface are wrappers around the corresponding Lua C API functions,
+ * and requires a certain degree of familiarity with the Lua C API.
+ * If you are not that familiar with the Lua C API, you may want to read the Lua manual first
+ * or try out {@link LuaValue}-related API at the {@link LuaThread} interface.
+ * </p>
  */
 public interface Lua extends AutoCloseable, LuaThread {
     String GLOBAL_THROWABLE = "__jthrowable__";
@@ -102,6 +109,11 @@ public interface Lua extends AutoCloseable, LuaThread {
 
     /**
      * Pushes a buffer as a raw string onto the stack
+     *
+     * <p>
+     * The pushed bytes are from buffer[buffer.position()] to buffer[buffer.limit() - 1].
+     * So remember to call {@link ByteBuffer#flip()} or set the position and limit before pushing.
+     * </p>
      *
      * @param buffer the buffer, which might contain invalid UTF-8 characters and zeros
      */
@@ -557,6 +569,8 @@ public interface Lua extends AutoCloseable, LuaThread {
      * </p>
      *
      * @param index the non-pseudo index
+     * @see #pushValue(int)
+     * @see #replace(int)
      */
     void insert(int index);
 
@@ -571,6 +585,8 @@ public interface Lua extends AutoCloseable, LuaThread {
      * Pushes a copy of the element at the given valid index onto the stack
      *
      * @param index the index of the element to be copied
+     * @see #insert(int)
+     * @see #replace(int)
      */
     void pushValue(int index);
 
@@ -602,6 +618,8 @@ public interface Lua extends AutoCloseable, LuaThread {
      * </p>
      *
      * @param index the index to move to
+     * @see #insert(int)
+     * @see #pushValue(int)
      */
     void replace(int index);
 
@@ -625,23 +643,33 @@ public interface Lua extends AutoCloseable, LuaThread {
      * Loads a string as a Lua chunk
      *
      * <p>
-     * This function uses {@code luaL_loadstring} to load the chunk.
+     * This function eventually uses {@code lua_load} to load the chunk in the string {@code script}.
+     * <strong>Also as lua_load, this function only loads the chunk; it does not run it.</strong>
      * </p>
      *
      * @param script the Lua chunk
+     * @see #run(String)
+     * @see #pCall(int, int)
      */
     void load(String script) throws LuaException;
-
 
     /**
      * Loads a buffer as a Lua chunk
      *
      * <p>
-     * This function uses {@code luaL_loadbuffer} to load the chunk.
+     * This function eventually uses {@code lua_load} to load the chunk in the string {@code script}.
+     * <strong>Also as lua_load, this function only loads the chunk; it does not run it.</strong>
+     * </p>
+     *
+     * <p>
+     * The used contents are from buffer[buffer.position()] to buffer[buffer.limit() - 1].
+     * So remember to call {@link ByteBuffer#flip()} or set the position and limit before pushing.
      * </p>
      *
      * @param buffer the buffer, must be a direct buffer
      * @param name   the chunk name, used for debug information and error messages
+     * @see #run(Buffer, String)
+     * @see #pCall(int, int)
      */
     void load(Buffer buffer, String name) throws LuaException;
 
@@ -649,7 +677,7 @@ public interface Lua extends AutoCloseable, LuaThread {
      * Loads and runs the given string
      *
      * <p>
-     * This function uses {@code luaL_dostring} to run the chunk.
+     * It is equivalent to first calling {@link #load(String)} and then {@link #pCall(int, int)} the loaded chunk.
      * </p>
      *
      * @param script the Lua chunk
@@ -657,11 +685,15 @@ public interface Lua extends AutoCloseable, LuaThread {
     void run(String script) throws LuaException;
 
     /**
-     * Loads and runa a buffer
+     * Loads and runs a buffer
      *
      * <p>
-     * This function uses {@code (luaL_loadbuffer(L, str) || lua_pcall(L, 0, LUA_MULTRET, 0))}
-     * to load and run the chunk.
+     * It is equivalent to first calling {@link #load(Buffer, String)} and then {@link #pCall(int, int)} the loaded chunk.
+     * </p>
+     *
+     * <p>
+     * The used contents are from buffer[buffer.position()] to buffer[buffer.limit() - 1].
+     * So remember to call {@link ByteBuffer#flip()} or set the position and limit before pushing.
      * </p>
      *
      * @param buffer the buffer, must be a direct buffer
@@ -756,10 +788,12 @@ public interface Lua extends AutoCloseable, LuaThread {
      * Yields a coroutine
      *
      * <p>
-     * This is not yet implemented yet.
+     * This is not implemented because we have no way to resume execution from a Java stack through a C stack
+     * back to a Java stack.
      * </p>
      *
      * @param n the number of values from the stack that are passed as results to lua_resume
+     * @throws UnsupportedOperationException always
      */
     void yield(int n);
 

--- a/luajava/src/main/java/party/iroiro/luajava/Lua.java
+++ b/luajava/src/main/java/party/iroiro/luajava/Lua.java
@@ -101,6 +101,13 @@ public interface Lua extends AutoCloseable, LuaThread {
     void push(@NotNull String string);
 
     /**
+     * Pushes a buffer as a raw string onto the stack
+     *
+     * @param buffer the buffer, which might contain invalid UTF-8 characters and zeros
+     */
+    void push(@NotNull ByteBuffer buffer);
+
+    /**
      * Push the element onto the stack, converted to lua tables
      *
      * <p>
@@ -773,7 +780,7 @@ public interface Lua extends AutoCloseable, LuaThread {
 
     /**
      * Creates a new empty table and pushes it onto the stack
-     * 
+     *
      * <p>
      * It is equivalent to {@link #createTable(int, int) createTable(0, 0)}.
      * </p>
@@ -1208,6 +1215,7 @@ public interface Lua extends AutoCloseable, LuaThread {
          * <ul>
          *     <li>Boolean -&gt; boolean</li>
          *     <li>String -&gt; string</li>
+         *     <li>ByteBuffer -&gt; string</li>
          *     <li>Number -&gt; lua_Number</li>
          *     <li>Map / Collection / Array -&gt; table (recursive)</li>
          *     <li>Object -&gt; Java object wrapped by a metatable {@link #pushJavaObject}</li>

--- a/luajava/src/main/java/party/iroiro/luajava/LuaNatives.java
+++ b/luajava/src/main/java/party/iroiro/luajava/LuaNatives.java
@@ -502,11 +502,12 @@ public interface LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    int luaJ_dobuffer(long ptr, Buffer buffer, int size, String name);
+    int luaJ_dobuffer(long ptr, Buffer buffer, int start, int size, String name);
 
     /**
      * A wrapper function
@@ -589,11 +590,12 @@ public interface LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    int luaJ_loadbuffer(long ptr, Buffer buffer, int size, String name);
+    int luaJ_loadbuffer(long ptr, Buffer buffer, int start, int size, String name);
 
     /**
      * A wrapper function
@@ -1757,9 +1759,10 @@ public interface LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      */
-    void luaJ_pushlstring(long ptr, Buffer buffer, int size);
+    void luaJ_pushlstring(long ptr, Buffer buffer, int start, int size);
 
     /**
      * A wrapper function

--- a/luajava/src/main/java/party/iroiro/luajava/LuaNatives.java
+++ b/luajava/src/main/java/party/iroiro/luajava/LuaNatives.java
@@ -1751,6 +1751,19 @@ public interface LuaNatives {
     /**
      * A wrapper function
      *
+     * <p>
+     * Push a buffer as a raw Lua string
+     * </p>
+     *
+     * @param ptr the <code>lua_State*</code> pointer
+     * @param buffer the buffer (expecting direct)
+     * @param size size
+     */
+    void luaJ_pushlstring(long ptr, Buffer buffer, int size);
+
+    /**
+     * A wrapper function
+     *
      * <p>Push a Java object</p>
      *
      * @param ptr the <code>lua_State*</code> pointer

--- a/luajava/src/main/java/party/iroiro/luajava/value/AbstractLuaValue.java
+++ b/luajava/src/main/java/party/iroiro/luajava/value/AbstractLuaValue.java
@@ -25,6 +25,7 @@ package party.iroiro.luajava.value;
 import org.jetbrains.annotations.NotNull;
 import party.iroiro.luajava.Lua;
 
+import java.nio.ByteBuffer;
 import java.util.AbstractMap;
 import java.util.Objects;
 import java.util.Set;
@@ -119,6 +120,14 @@ public abstract class AbstractLuaValue<T extends Lua>
     @Override
     public boolean toBoolean() {
         return toInteger() != 0;
+    }
+
+    @Override
+    public ByteBuffer toBuffer() {
+        push(L);
+        ByteBuffer buffer = L.toBuffer(-1);
+        L.pop(1);
+        return buffer;
     }
 
     @Override

--- a/luajava/src/main/java/party/iroiro/luajava/value/LuaThread.java
+++ b/luajava/src/main/java/party/iroiro/luajava/value/LuaThread.java
@@ -2,6 +2,8 @@ package party.iroiro.luajava.value;
 
 import party.iroiro.luajava.LuaException;
 
+import java.nio.ByteBuffer;
+
 public interface LuaThread {
     /**
      * Sets a global variable to the given value
@@ -63,4 +65,10 @@ public interface LuaThread {
      * @return a string Lua value
      */
     LuaValue from(String s);
+
+    /**
+     * @param buffer the content of the raw string
+     * @return a raw string Lua value
+     */
+    LuaValue from(ByteBuffer buffer);
 }

--- a/luajava/src/main/java/party/iroiro/luajava/value/LuaThread.java
+++ b/luajava/src/main/java/party/iroiro/luajava/value/LuaThread.java
@@ -38,6 +38,20 @@ public interface LuaThread {
     LuaValue[] eval(String command) throws LuaException;
 
     /**
+     * Loads a module, similar to the Lua `require` function
+     *
+     * <p>
+     * Please note that this method will attempt to call
+     * {@link party.iroiro.luajava.Lua#openLibrary(String) Lua.openLibrary("package")} first and
+     * cache the global {@code require} function.
+     * </p>
+     *
+     * @param module the module name
+     * @return the module
+     */
+    LuaValue require(String module) throws LuaException;
+
+    /**
      * @return a nil Lua value
      */
     LuaValue fromNull();

--- a/luajava/src/main/java/party/iroiro/luajava/value/LuaValue.java
+++ b/luajava/src/main/java/party/iroiro/luajava/value/LuaValue.java
@@ -26,6 +26,8 @@ import org.jetbrains.annotations.Nullable;
 import party.iroiro.luajava.Lua;
 import party.iroiro.luajava.LuaException;
 
+import java.nio.ByteBuffer;
+
 /**
  * A simple wrapper of references to Lua values
  */
@@ -69,6 +71,8 @@ public interface LuaValue extends LuaTableTrait {
     double toNumber();
 
     String toString();
+
+    ByteBuffer toBuffer();
 
     /**
      * Creates a proxy from this value with {@link Lua#createProxy(Class[], Lua.Conversion)}.

--- a/luajit/jni/mod/luacomp.h
+++ b/luajit/jni/mod/luacomp.h
@@ -50,14 +50,6 @@ static int luaJ_len(lua_State * L, int index) {
     return lua_objlen(L, index);
 }
 
-static int luaJ_loadbuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return luaL_loadbuffer(L, (const char *) buffer, size, name);
-}
-
-static int luaJ_dobuffer(lua_State * L, unsigned char * buffer, int size, const char * name) {
-    return (luaL_loadbuffer(L, (const char *) buffer, size, name) || lua_pcall(L, 0, LUA_MULTRET, 0));
-}
-
 static int luaJ_resume(lua_State * L, int narg) {
     return lua_resume(L, narg);
 }

--- a/luajit/src/main/java/party/iroiro/luajava/luajit/LuaJitNatives.java
+++ b/luajit/src/main/java/party/iroiro/luajava/luajit/LuaJitNatives.java
@@ -3446,6 +3446,24 @@ public class LuaJitNatives implements LuaNatives {
      * A wrapper function
      *
      * <p>
+     * Push a buffer as a raw Lua string
+     * </p>
+     *
+     * @param ptr the <code>lua_State*</code> pointer
+     * @param buffer the buffer (expecting direct)
+     * @param size size
+     */
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+        lua_State * L = (lua_State *) ptr;
+
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
+    */
+
+
+    /**
+     * A wrapper function
+     *
+     * <p>
      * Is a Java object (including object, array or class)
      * </p>
      *

--- a/luajit/src/main/java/party/iroiro/luajava/luajit/LuaJitNatives.java
+++ b/luajit/src/main/java/party/iroiro/luajava/luajit/LuaJitNatives.java
@@ -3322,14 +3322,15 @@ public class LuaJitNatives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_loadbuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_loadbuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -3343,14 +3344,15 @@ public class LuaJitNatives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      * @param name the name
      * @return see description
      */
-    public native int luaJ_dobuffer(long ptr, Buffer buffer, int size, String name); /*
+    public native int luaJ_dobuffer(long ptr, Buffer buffer, int start, int size, String name); /*
         lua_State * L = (lua_State *) ptr;
 
-        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) size, (const char *) name);
+        jint returnValueReceiver = (jint) luaJ_dobuffer((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size, (const char *) name);
         return returnValueReceiver;
     */
 
@@ -3451,12 +3453,13 @@ public class LuaJitNatives implements LuaNatives {
      *
      * @param ptr the <code>lua_State*</code> pointer
      * @param buffer the buffer (expecting direct)
+     * @param start the starting index
      * @param size size
      */
-    public native void luaJ_pushlstring(long ptr, Buffer buffer, int size); /*
+    public native void luaJ_pushlstring(long ptr, Buffer buffer, int start, int size); /*
         lua_State * L = (lua_State *) ptr;
 
-        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) size);
+        luaJ_pushlstring((lua_State *) L, (unsigned char *) buffer, (int) start, (int) size);
     */
 
 

--- a/scripts/jnigen-lua.py
+++ b/scripts/jnigen-lua.py
@@ -252,6 +252,7 @@ paramTypedDescriptions = {
     's': {'const char *': 'the string'},
     'sig': {'const char *': 'the method signature used in {@code GetMethodID}'},
     'size': {'size_t': 'size', 'int': 'size'},
+    'start': {'int': 'the starting index'},
     'stat': {'int': '(I have no idea)'},
     'str': {'const char *': 'string'},
     't': {'int': 'the stack index'},
@@ -562,6 +563,7 @@ extraFunctions = [
             params=[
                 ('lua_State *', 'L'),
                 ('unsigned char *', 'buffer'),
+                ('int', 'start'),
                 ('int', 'size'),
                 ('const char *', 'name'),
             ],
@@ -575,6 +577,7 @@ extraFunctions = [
             params=[
                 ('lua_State *', 'L'),
                 ('unsigned char *', 'buffer'),
+                ('int', 'start'),
                 ('int', 'size'),
                 ('const char *', 'name'),
             ],
@@ -647,6 +650,7 @@ extraFunctions = [
             params=[
                 ('lua_State *', 'L'),
                 ('unsigned char *', 'buffer'),
+                ('int', 'start'),
                 ('int', 'size'),
             ],
         ),

--- a/scripts/jnigen-lua.py
+++ b/scripts/jnigen-lua.py
@@ -640,6 +640,18 @@ extraFunctions = [
         ),
     ),
     LuaAPI(
+        name='luaJ_pushlstring',
+        description='Push a buffer as a raw Lua string',
+        signature=FunctionSignature(
+            returns='void',
+            params=[
+                ('lua_State *', 'L'),
+                ('unsigned char *', 'buffer'),
+                ('int', 'size'),
+            ],
+        ),
+    ),
+    LuaAPI(
         name='luaJ_isobject',
         description='Is a Java object (including object, array or class)',
         signature=FunctionSignature(


### PR DESCRIPTION
This PR adds a few API to facilitate content loading:

Buffers:
- `ByteBuffer` conversions via `Lua::push`
- Lua strings will be converted to `ByteBuffer` if Java typing requires so.
- One can now turn `LuaValue`s into buffers (or vice versa).

Documentation:
- Javadoc for `Lua::load` is furnished, hopefully preventing misusages.

`luaL_dofile` equivalence:
- Add `Lua::require`.
- Encourage using `Lua::require` instead of relying on a filesystem.

Hopefully closes #207, #209 and #210